### PR TITLE
Implement the auth api endpoint

### DIFF
--- a/backend/app/auth/api.py
+++ b/backend/app/auth/api.py
@@ -5,14 +5,17 @@ All routes delegate to AuthService for business logic.
 """
 
 from typing import AsyncGenerator
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
+import jwt
 
 from app.auth.auth_local_service import AuthLocalService
 from app.auth.service import AuthService
 from app.auth.sql_repository import SqlUserRepository
-from app.auth.schemas import UserCreate, User
+from app.auth.schemas import LoginRequest, TokenResponse, UserCreate, User
+from app.auth.helper import create_access_token
 from app.core.settings import settings
 from app.db.session import DatabaseEngine
 
@@ -72,16 +75,36 @@ async def signup(
         ) from exc
 
 
-@router.post("/login")
-async def login(email: str, password: str):
+@router.post("/login", response_model=TokenResponse)
+async def login(
+    credentials: LoginRequest,
+    auth_service: AuthService = Depends(get_auth_service),
+) -> TokenResponse:
     """
     Authenticate user and return JWT access token.
-    
-    Returns:
-    - **access_token**: JWT token valid for subsequent requests
-    - **token_type**: "bearer"
+
+    The endpoint verifies the supplied credentials against the local-auth
+    backend and, on success, issues a signed JWT access token the client
+    can use for subsequent authenticated requests.
+
+    :param credentials: Login payload containing the user's email address
+        and plain-text password.
+    :param auth_service: Authentication service responsible for verifying
+        credentials against the stored password hash.
+    :return: A bearer token response containing the signed JWT access token
+        and its type.
+    :raises HTTPException: Returns ``401 Unauthorized`` when the supplied
+        credentials are invalid or the email does not exist.
     """
-    raise NotImplementedError
+    user = await auth_service.authenticate(credentials.email, credentials.password)
+    access_token = create_access_token(user.id) if user else None
+    if access_token is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid email or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return TokenResponse(access_token=access_token)
 
 
 @router.post("/logout")

--- a/backend/app/auth/api.py
+++ b/backend/app/auth/api.py
@@ -4,26 +4,72 @@ Auth API routes: signup, login, logout.
 All routes delegate to AuthService for business logic.
 """
 
-from fastapi import APIRouter, HTTPException
+from typing import AsyncGenerator
 
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.auth_local_service import AuthLocalService
+from app.auth.service import AuthService
+from app.auth.sql_repository import SqlUserRepository
 from app.auth.schemas import UserCreate, User
+from app.core.settings import settings
+from app.db.session import DatabaseEngine
 
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
-@router.post("/signup", response_model=User)
-async def signup(user_data: UserCreate):
+db_engine = DatabaseEngine(database_url=settings.db_url)
+
+
+async def get_db_session() -> AsyncGenerator[AsyncSession, None]:
+    """Yield an async database session for auth route dependencies.
+
+    :return: An async generator yielding an active SQLAlchemy session.
     """
-    Register a new user.
-    
-    - **username**: Unique username (1-255 chars)
-    - **email**: Valid email address
-    - **password**: Password (1-255 chars, will be hashed)
-    - **github_page**: Optional GitHub profile URL
-    - **bio**: Optional bio text
+    async with db_engine.async_session() as session:
+        yield session
+
+
+def get_auth_service(session: AsyncSession = Depends(get_db_session)) -> AuthService:
+    """Build the auth service used by route handlers.
+
+    :param session: Request-scoped asynchronous database session.
+    :return: A concrete auth service implementation for local auth.
     """
-    raise NotImplementedError
+    repository = SqlUserRepository(session)
+    return AuthLocalService(repository)
+
+
+@router.post("/signup", status_code=status.HTTP_201_CREATED, response_model=User)
+async def signup(
+    user_data: UserCreate,
+    auth_service: AuthService = Depends(get_auth_service),
+) -> User:
+    """
+    Register a new local-auth user account.
+
+    This endpoint validates incoming user data, delegates account creation to
+    the auth service, and returns the created public user profile.
+
+    :param user_data: Signup payload containing username, email, plain-text
+        password, and optional profile metadata.
+    :param auth_service: Authentication service responsible for applying
+        registration business rules such as duplicate-email checks and
+        password hashing.
+    :return: The newly created user profile serialized with the response
+        schema.
+    :raises HTTPException: Returns ``409 Conflict`` when a user with the same
+        email already exists.
+    """
+    try:
+        return await auth_service.register(user_data)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
 
 
 @router.post("/login")

--- a/backend/app/auth/api.py
+++ b/backend/app/auth/api.py
@@ -8,6 +8,7 @@ from typing import AsyncGenerator
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 import jwt
 
@@ -15,12 +16,15 @@ from app.auth.auth_local_service import AuthLocalService
 from app.auth.service import AuthService
 from app.auth.sql_repository import SqlUserRepository
 from app.auth.schemas import LoginRequest, TokenResponse, UserCreate, User
-from app.auth.helper import create_access_token
+from app.auth.helper import create_access_token, revoke_access_token
 from app.core.settings import settings
 from app.db.session import DatabaseEngine
 
 
 router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+bearer_scheme = HTTPBearer(auto_error=False)
 
 
 db_engine = DatabaseEngine(database_url=settings.db_url)
@@ -108,13 +112,38 @@ async def login(
 
 
 @router.post("/logout")
-async def logout():
+async def logout(
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+) -> dict[str, str]:
     """
-    Logout (stateless: client discards token).
-    
-    For stateful logout with token blacklist, further implementation needed.
+    Logout the current JWT-authenticated user session.
+
+    This endpoint reads the bearer token from the ``Authorization`` header,
+    validates it, and revokes its ``jti`` in an in-memory denylist so the
+    token cannot be accepted again by revocation-aware checks.
+
+    :param credentials: Parsed HTTP bearer authorization credentials.
+    :return: Confirmation message indicating the logout operation succeeded.
+    :raises HTTPException: Returns ``401 Unauthorized`` when the bearer token
+        is missing, malformed, or invalid.
     """
-    raise NotImplementedError
+    if credentials is None or credentials.scheme.lower() != "bearer":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    try:
+        revoke_access_token(credentials.credentials)
+    except jwt.InvalidTokenError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid access token",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from exc
+
+    return {"detail": "Logged out successfully"}
 
 
 @router.get("/me", response_model=User)

--- a/backend/app/auth/helper.py
+++ b/backend/app/auth/helper.py
@@ -1,0 +1,72 @@
+from datetime import datetime, timedelta, timezone
+from typing import Iterable
+
+import jwt
+from jwt import InvalidTokenError
+
+from app.core.settings import settings
+
+def _previous_jwt_secrets() -> list[str]:
+    """Parse previous JWT secrets from settings.
+
+    :return: A list of previous JWT secret keys for token verification.
+    """
+    secrets_str = settings.JWT_PREVIOUS_SECRETS
+    if not secrets_str:
+        return []
+    return [s.strip() for s in secrets_str.split(",") if s.strip()]
+
+def create_access_token(user_id: int) -> str:
+    """Create a JWT access token for the given user ID.
+
+    :param user_id: The ID of the user for whom to create the token.
+    :return: A signed JWT access token string.
+    """
+    now = datetime.now(timezone.utc)
+    payload = {
+        "sub": str(user_id),
+        "iat": now,
+        "exp": now + timedelta(minutes=settings.JWT_EXPIRATION_MINUTES),
+    }
+    return jwt.encode(
+        payload,
+        settings.JWT_CURRENT_SECRET,
+        algorithm=settings.JWT_ALGORITHM,
+    )
+
+def _candidate_secrets() -> Iterable[str]:
+    """Generate candidate secrets for JWT verification.
+
+    This includes the current secret and any previous secrets configured in
+    settings, allowing for seamless secret rotation without invalidating tokens.
+
+    :return: An iterable of candidate secret keys to try for token verification.
+    """
+    yield settings.JWT_CURRENT_SECRET
+    yield from _previous_jwt_secrets()
+
+def decode_access_token(token: str) -> dict:
+    """Decode and verify a JWT access token against candidate secrets.
+
+    This function attempts to decode the token using the current secret and
+    any previous secrets configured in settings. If decoding succeeds with any
+    of the secrets, the decoded payload is returned. If all attempts fail,
+    an InvalidTokenError is raised.
+
+    :param token: The JWT access token string to decode and verify.
+    :return: The decoded token payload if verification succeeds.
+    :raises InvalidTokenError: If the token cannot be verified with any candidate secret.
+    """
+    last_exception = None
+    for secret in _candidate_secrets():
+        try:
+            return jwt.decode(
+                token,
+                secret,
+                algorithms=[settings.JWT_ALGORITHM],
+            )
+        except InvalidTokenError as exc:
+            last_exception = exc
+            continue
+
+    raise InvalidTokenError("Token verification failed with all candidate secrets") from last_exception

--- a/backend/app/auth/helper.py
+++ b/backend/app/auth/helper.py
@@ -1,10 +1,16 @@
 from datetime import datetime, timedelta, timezone
+from uuid import uuid4
 from typing import Iterable
 
 import jwt
 from jwt import InvalidTokenError
 
 from app.core.settings import settings
+
+
+# In-memory token denylist keyed by JWT `jti` with expiration timestamp.
+# This is suitable for single-process development and tests only.
+_REVOKED_JTIS: dict[str, int] = {}
 
 def _previous_jwt_secrets() -> list[str]:
     """Parse previous JWT secrets from settings.
@@ -25,6 +31,7 @@ def create_access_token(user_id: int) -> str:
     now = datetime.now(timezone.utc)
     payload = {
         "sub": str(user_id),
+        "jti": str(uuid4()),
         "iat": now,
         "exp": now + timedelta(minutes=settings.JWT_EXPIRATION_MINUTES),
     }
@@ -45,7 +52,7 @@ def _candidate_secrets() -> Iterable[str]:
     yield settings.JWT_CURRENT_SECRET
     yield from _previous_jwt_secrets()
 
-def decode_access_token(token: str) -> dict:
+def decode_access_token(token: str, *, verify_exp: bool = True) -> dict:
     """Decode and verify a JWT access token against candidate secrets.
 
     This function attempts to decode the token using the current secret and
@@ -54,6 +61,7 @@ def decode_access_token(token: str) -> dict:
     an InvalidTokenError is raised.
 
     :param token: The JWT access token string to decode and verify.
+    :param verify_exp: Whether to enforce expiration claim validation.
     :return: The decoded token payload if verification succeeds.
     :raises InvalidTokenError: If the token cannot be verified with any candidate secret.
     """
@@ -64,9 +72,59 @@ def decode_access_token(token: str) -> dict:
                 token,
                 secret,
                 algorithms=[settings.JWT_ALGORITHM],
+                options={"verify_exp": verify_exp},
             )
         except InvalidTokenError as exc:
             last_exception = exc
             continue
 
     raise InvalidTokenError("Token verification failed with all candidate secrets") from last_exception
+
+
+def _cleanup_revoked_jtis(now_ts: int) -> None:
+    """Remove expired entries from the in-memory JWT denylist.
+
+    :param now_ts: Current UTC timestamp used to evict stale entries.
+    :return: None.
+    """
+    expired = [jti for jti, exp_ts in _REVOKED_JTIS.items() if exp_ts <= now_ts]
+    for jti in expired:
+        _REVOKED_JTIS.pop(jti, None)
+
+
+def revoke_access_token(token: str) -> None:
+    """Revoke an access token by storing its JTI until expiration.
+
+    :param token: Encoded JWT access token to revoke.
+    :return: None.
+    :raises InvalidTokenError: Raised when token decoding fails or required
+        claims are missing.
+    """
+    payload = decode_access_token(token, verify_exp=False)
+    token_jti = payload.get("jti")
+    token_exp = payload.get("exp")
+    if not isinstance(token_jti, str) or not token_jti:
+        raise InvalidTokenError("Missing or invalid jti claim")
+    if not isinstance(token_exp, int):
+        raise InvalidTokenError("Missing or invalid exp claim")
+
+    now_ts = int(datetime.now(timezone.utc).timestamp())
+    _cleanup_revoked_jtis(now_ts)
+    _REVOKED_JTIS[token_jti] = token_exp
+
+
+def is_access_token_revoked(token: str) -> bool:
+    """Check whether an access token has been revoked.
+
+    :param token: Encoded JWT access token to inspect.
+    :return: ``True`` when the token JTI exists in the denylist,
+        otherwise ``False``.
+    """
+    payload = decode_access_token(token, verify_exp=False)
+    token_jti = payload.get("jti")
+    if not isinstance(token_jti, str) or not token_jti:
+        return False
+
+    now_ts = int(datetime.now(timezone.utc).timestamp())
+    _cleanup_revoked_jtis(now_ts)
+    return token_jti in _REVOKED_JTIS

--- a/backend/app/auth/schemas.py
+++ b/backend/app/auth/schemas.py
@@ -73,3 +73,25 @@ class User(UserBase):
     id: BigIntId
     created_at: datetime
     updated_at: datetime
+
+
+class LoginRequest(BaseModel):
+    """Input schema for local-auth login.
+
+    Carries credentials as a validated request body to avoid exposing
+    sensitive values in query parameters or URL paths.
+    """
+
+    email: EmailStr
+    password: UserString
+
+
+class TokenResponse(BaseModel):
+    """Output schema returned upon successful authentication.
+
+    Follows the OAuth2 bearer token response convention so clients can
+    treat the ``access_token`` uniformly regardless of the auth backend.
+    """
+
+    access_token: str
+    token_type: str = "bearer"

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -71,6 +71,10 @@ class PSQLSettings(DBSettings):
     POSTGRES_DB: str
     POSTGRES_HOST: str = "localhost"
     POSTGRES_PORT: int = 5432
+    JWT_CURRENT_SECRET: str = "changeme-replace-this-key-in-production-env"
+    JWT_PREVIOUS_SECRETS: str = ""
+    JWT_ALGORITHM: str = "HS256"
+    JWT_EXPIRATION_MINUTES: int = 30
 
     @property
     def db_url(self) -> str:

--- a/backend/pixi.lock
+++ b/backend/pixi.lock
@@ -76,6 +76,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
@@ -166,6 +167,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.13-ha9537fe_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
@@ -255,6 +257,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.13-h8561d8f_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
@@ -337,6 +340,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.13-h0159041_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
@@ -1898,6 +1902,19 @@ packages:
   license_family: BSD
   size: 893031
   timestamp: 1774796815820
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
+  sha256: 4279ee4cf2533fd17910ae7373159d9bee2492d8c50932ddc74dd27a70b15de4
+  md5: b27a9f4eca2925036e43542488d3a804
+  depends:
+  - python >=3.10
+  - typing_extensions >=4.0
+  - python
+  constrains:
+  - cryptography >=3.4.0
+  license: MIT
+  license_family: MIT
+  size: 32247
+  timestamp: 1773482160904
 - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
   sha256: 9e749fb465a8bedf0184d8b8996992a38de351f7c64e967031944978de03a520
   md5: 2b694bad8a50dc2f712f5368de866480

--- a/backend/pixi.toml
+++ b/backend/pixi.toml
@@ -19,6 +19,7 @@ python-dotenv = ">=1.0.1"
 pytest = ">=9.0.2,<10"
 aiosqlite = ">=0.22.1,<0.23"
 alembic = ">=1.18.4,<2"
+pyjwt = ">=2.8.0,<3"
 
 [tasks]
 # Task to start the development server with hot reload

--- a/backend/tests/test_auth_api_login.py
+++ b/backend/tests/test_auth_api_login.py
@@ -1,0 +1,498 @@
+import asyncio
+import os
+from datetime import datetime
+from typing import Optional
+
+import jwt
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Ensure settings can be instantiated when importing app.auth.api.
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_DB", "test")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+os.environ.setdefault("JWT_SECRET_KEY", "test-jwt-secret-key-at-least-32-bytes")
+os.environ.setdefault("JWT_ALGORITHM", "HS256")
+os.environ.setdefault("JWT_EXPIRATION_MINUTES", "30")
+
+from app.auth import api as auth_api
+from app.auth.schemas import LoginRequest, TokenResponse, User
+
+
+NOW = datetime(2026, 4, 12, 10, 30, 0)
+
+TEST_JWT_ALGORITHM = os.environ["JWT_ALGORITHM"]
+TEST_JWT_SECRET_KEY = os.environ["JWT_SECRET_KEY"]
+TEST_JWT_EXPIRATION_MINUTES = int(os.environ["JWT_EXPIRATION_MINUTES"])
+
+
+class FakeAuthService:
+    def __init__(
+        self,
+        *,
+        user_to_return: Optional[User] = None,
+        error_to_raise: Optional[Exception] = None,
+    ):
+        """Initialize a configurable fake auth service for login tests.
+
+        :param user_to_return: User instance returned by ``authenticate`` when
+            authentication succeeds. Pass ``None`` to simulate invalid
+            credentials.
+        :param error_to_raise: Exception raised by ``authenticate`` to test
+            unexpected error propagation.
+        :return: None.
+        """
+        self.user_to_return = user_to_return
+        self.error_to_raise = error_to_raise
+        self.authenticate_calls = 0
+        self.last_email: Optional[str] = None
+        self.last_password: Optional[str] = None
+
+    async def authenticate(self, email: str, password: str) -> Optional[User]:
+        """Simulate credential verification for login unit tests.
+
+        The method records invocation metadata so tests can assert delegation
+        behavior and credential forwarding from the API layer.
+
+        :param email: Email address received by the fake service.
+        :param password: Plain-text password received by the fake service.
+        :return: Preconfigured user instance when no error is configured, or
+            ``None`` to simulate invalid credentials.
+        :raises Exception: Re-raises the configured ``error_to_raise`` when
+            present.
+        """
+        self.authenticate_calls += 1
+        self.last_email = email
+        self.last_password = password
+        if self.error_to_raise is not None:
+            raise self.error_to_raise
+        return self.user_to_return
+
+
+def _build_user(
+    *,
+    user_id: int = 1,
+    username: str = "alice",
+    email: str = "alice@example.com",
+) -> User:
+    """Create a deterministic user fixture for login endpoint tests.
+
+    :param user_id: Identifier assigned to the returned user model.
+    :param username: Username assigned to the returned user model.
+    :param email: Email assigned to the returned user model.
+    :return: A fully populated ``User`` instance with stable timestamps.
+    """
+    return User(
+        id=user_id,
+        username=username,
+        email=email,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _build_client(
+    fake_service: FakeAuthService,
+    *,
+    raise_server_exceptions: bool = True,
+) -> TestClient:
+    """Build a FastAPI test client with auth service dependency overridden.
+
+    :param fake_service: Fake service injected into the auth router
+        dependency graph.
+    :param raise_server_exceptions: When ``False``, server-side errors are
+        returned as 500 responses instead of being re-raised in the test
+        process.
+    :return: Configured ``TestClient`` ready for login endpoint tests.
+    """
+    app = FastAPI()
+    app.include_router(auth_api.router)
+    app.dependency_overrides[auth_api.get_auth_service] = lambda: fake_service
+    return TestClient(app, raise_server_exceptions=raise_server_exceptions)
+
+
+def _decode_token(token: str) -> dict:
+    """Decode a JWT using the test secret without verifying expiry.
+
+    :param token: Encoded JWT string to decode.
+    :return: Decoded payload as a dictionary.
+    """
+    return jwt.decode(
+        token,
+        options={"verify_signature": False},
+        algorithms=[TEST_JWT_ALGORITHM],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Success path
+# ---------------------------------------------------------------------------
+
+def test_login_returns_200_on_valid_credentials():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "alice@example.com", "password": "plain-password"},
+    )
+
+    assert response.status_code == 200
+
+
+def test_login_response_contains_access_token_field():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "alice@example.com", "password": "plain-password"},
+    )
+
+    assert "access_token" in response.json()
+
+
+def test_login_response_token_type_is_bearer():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "alice@example.com", "password": "plain-password"},
+    )
+
+    assert response.json()["token_type"] == "bearer"
+
+
+def test_login_access_token_is_non_empty_string():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "alice@example.com", "password": "plain-password"},
+    )
+
+    token = response.json()["access_token"]
+    assert isinstance(token, str)
+    assert len(token) > 0
+
+
+def test_login_access_token_has_three_jwt_parts():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "alice@example.com", "password": "plain-password"},
+    )
+
+    token = response.json()["access_token"]
+    parts = token.split(".")
+    assert len(parts) == 3
+
+
+def test_login_response_does_not_expose_password():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "alice@example.com", "password": "plain-password"},
+    )
+
+    assert "password" not in response.json()
+
+
+# ---------------------------------------------------------------------------
+# Service delegation
+# ---------------------------------------------------------------------------
+
+def test_login_calls_authenticate_once_on_success():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "alice@example.com", "password": "plain-password"},
+    )
+
+    assert response.status_code == 200
+    assert fake_service.authenticate_calls == 1
+
+
+def test_login_passes_email_to_service_authenticate():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    client.post(
+        "/auth/login",
+        json={"email": "alice@example.com", "password": "plain-password"},
+    )
+
+    assert fake_service.last_email == "alice@example.com"
+
+
+def test_login_passes_password_to_service_authenticate():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    client.post(
+        "/auth/login",
+        json={"email": "alice@example.com", "password": "plain-password"},
+    )
+
+    assert fake_service.last_password == "plain-password"
+
+
+# ---------------------------------------------------------------------------
+# JWT payload
+# ---------------------------------------------------------------------------
+
+def test_login_token_sub_claim_matches_user_id():
+    fake_service = FakeAuthService(user_to_return=_build_user(user_id=42))
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "alice@example.com", "password": "plain-password"},
+    )
+
+    token = response.json()["access_token"]
+    payload = _decode_token(token)
+    assert payload["sub"] == "42"
+
+
+def test_login_token_contains_exp_claim():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "alice@example.com", "password": "plain-password"},
+    )
+
+    token = response.json()["access_token"]
+    payload = _decode_token(token)
+    assert "exp" in payload
+
+
+def test_login_token_contains_iat_claim():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "alice@example.com", "password": "plain-password"},
+    )
+
+    token = response.json()["access_token"]
+    payload = _decode_token(token)
+    assert "iat" in payload
+
+
+# ---------------------------------------------------------------------------
+# 401 Unauthorized
+# ---------------------------------------------------------------------------
+
+def test_login_returns_401_when_service_returns_none():
+    fake_service = FakeAuthService(user_to_return=None)
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "alice@example.com", "password": "wrong-password"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_login_401_detail_message_is_explicit():
+    fake_service = FakeAuthService(user_to_return=None)
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "alice@example.com", "password": "wrong-password"},
+    )
+
+    assert response.json()["detail"] == "Invalid email or password"
+
+
+def test_login_401_includes_www_authenticate_header():
+    fake_service = FakeAuthService(user_to_return=None)
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "alice@example.com", "password": "wrong-password"},
+    )
+
+    assert response.headers.get("www-authenticate") == "Bearer"
+
+
+# ---------------------------------------------------------------------------
+# Request validation (422)
+# ---------------------------------------------------------------------------
+
+def test_login_returns_422_for_empty_body():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post("/auth/login", json={})
+
+    assert response.status_code == 422
+
+
+def test_login_returns_422_when_email_is_missing():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post("/auth/login", json={"password": "plain-password"})
+
+    assert response.status_code == 422
+
+
+def test_login_returns_422_when_password_is_missing():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post("/auth/login", json={"email": "alice@example.com"})
+
+    assert response.status_code == 422
+
+
+def test_login_returns_422_for_invalid_email_format():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "not-an-email", "password": "plain-password"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_login_returns_422_for_empty_password():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "alice@example.com", "password": ""},
+    )
+
+    assert response.status_code == 422
+
+
+def test_login_returns_422_for_password_longer_than_255():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "alice@example.com", "password": "p" * 256},
+    )
+
+    assert response.status_code == 422
+
+
+def test_login_validation_short_circuits_service_call():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "not-an-email", "password": "plain-password"},
+    )
+
+    assert response.status_code == 422
+    assert fake_service.authenticate_calls == 0
+
+
+def test_login_returns_422_for_malformed_json_body():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/login",
+        content='{"email": "alice@example.com",',
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 422
+    assert fake_service.authenticate_calls == 0
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+def test_login_does_not_map_unexpected_service_error_to_401():
+    fake_service = FakeAuthService(error_to_raise=RuntimeError("unexpected failure"))
+    client = _build_client(fake_service, raise_server_exceptions=False)
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "alice@example.com", "password": "plain-password"},
+    )
+
+    assert response.status_code == 500
+
+
+def test_login_ignores_extra_input_fields_by_contract():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/login",
+        json={
+            "email": "alice@example.com",
+            "password": "plain-password",
+            "unexpected_field": "should be ignored",
+        },
+    )
+
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Direct route function tests
+# ---------------------------------------------------------------------------
+
+def test_login_route_function_returns_token_response_on_success():
+    async def run_test():
+        fake_service = FakeAuthService(user_to_return=_build_user(user_id=7))
+        credentials = LoginRequest(
+            email="alice@example.com",
+            password="plain-password",
+        )
+
+        result = await auth_api.login(credentials, fake_service)
+
+        assert isinstance(result, TokenResponse)
+        assert result.token_type == "bearer"
+        assert len(result.access_token) > 0
+
+    asyncio.run(run_test())
+
+
+def test_login_route_function_raises_http_401_when_service_returns_none():
+    async def run_test():
+        fake_service = FakeAuthService(user_to_return=None)
+        credentials = LoginRequest(
+            email="alice@example.com",
+            password="wrong-password",
+        )
+
+        try:
+            await auth_api.login(credentials, fake_service)
+            raise AssertionError("Expected HTTPException for invalid credentials")
+        except Exception as exc:  # noqa: BLE001 - explicit behavior assertion.
+            assert exc.status_code == 401
+            assert exc.detail == "Invalid email or password"
+
+    asyncio.run(run_test())

--- a/backend/tests/test_auth_api_logout.py
+++ b/backend/tests/test_auth_api_logout.py
@@ -1,0 +1,377 @@
+import os
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import jwt
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Ensure settings can be instantiated when importing app.auth.api.
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_DB", "test")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+os.environ.setdefault(
+    "JWT_CURRENT_SECRET",
+    "test-jwt-current-secret-key-at-least-32-bytes",
+)
+os.environ.setdefault("JWT_ALGORITHM", "HS256")
+os.environ.setdefault("JWT_EXPIRATION_MINUTES", "30")
+
+from app.auth import api as auth_api
+from app.auth.helper import (
+    create_access_token,
+    decode_access_token,
+    is_access_token_revoked,
+)
+from app.core.settings import settings
+
+
+def _build_client() -> TestClient:
+    """Build a FastAPI test client with the auth router mounted.
+
+    :return: Configured ``TestClient`` for auth endpoint tests.
+    """
+    app = FastAPI()
+    app.include_router(auth_api.router)
+    return TestClient(app)
+
+
+def _jwt_secret() -> str:
+    """Return the JWT secret used by tests.
+
+    :return: JWT secret string.
+    """
+    return settings.JWT_CURRENT_SECRET
+
+
+def _jwt_algorithm() -> str:
+    """Return the JWT algorithm used by tests.
+
+    :return: JWT algorithm string.
+    """
+    return settings.JWT_ALGORITHM
+
+
+def _encode_payload(payload: dict) -> str:
+    """Encode a payload with the current test JWT secret.
+
+    :param payload: JWT payload to encode.
+    :return: Encoded JWT string.
+    """
+    return jwt.encode(payload, _jwt_secret(), algorithm=_jwt_algorithm())
+
+
+def _valid_payload(*, sub: str = "1") -> dict:
+    """Build a valid JWT payload for logout tests.
+
+    :param sub: Subject claim value.
+    :return: Payload dictionary containing sub, jti, iat, exp.
+    """
+    now = datetime.now(timezone.utc)
+    return {
+        "sub": sub,
+        "jti": str(uuid4()),
+        "iat": now,
+        "exp": now + timedelta(minutes=30),
+    }
+
+
+def test_logout_returns_401_when_authorization_header_is_missing():
+    client = _build_client()
+
+    response = client.post("/auth/logout")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Not authenticated"
+
+
+@pytest.mark.parametrize(
+    "authorization_value",
+    [
+        "Basic abcdef",
+        "Digest abcdef",
+        "Token abcdef",
+        "ApiKey abcdef",
+        "Negotiate abcdef",
+        "OAuth abcdef",
+        "Bearer",
+        "",
+        "UnknownScheme token",
+        "bearer",
+        "Basic",
+        "Custom verycustomtoken",
+    ],
+)
+def test_logout_rejects_invalid_authorization_schemes(authorization_value: str):
+    client = _build_client()
+
+    response = client.post(
+        "/auth/logout",
+        headers={"Authorization": authorization_value},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Not authenticated"
+    assert response.headers.get("www-authenticate") == "Bearer"
+
+
+def test_logout_returns_401_when_bearer_scheme_is_not_used():
+    client = _build_client()
+
+    response = client.post(
+        "/auth/logout",
+        headers={"Authorization": "Basic abcdef"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Not authenticated"
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "not-a-jwt",
+        "abc",
+        "abc.def",
+        "abc.def.ghi",
+        "....",
+        "###",
+        "123.456.789",
+        "BearerInsideToken",
+        "eyJhbGciOiJIUzI1NiJ9.badpayload.signature",
+        "eyJhbGciOiJIUzI1NiJ9..signature",
+        "only-one-part",
+        "two.parts",
+    ],
+)
+def test_logout_returns_401_for_invalid_token_string(token: str):
+    client = _build_client()
+
+    response = client.post(
+        "/auth/logout",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid access token"
+    assert response.headers.get("www-authenticate") == "Bearer"
+
+
+def test_logout_returns_401_with_www_authenticate_header_for_missing_token():
+    client = _build_client()
+
+    response = client.post("/auth/logout")
+
+    assert response.headers.get("www-authenticate") == "Bearer"
+
+
+def test_logout_returns_401_with_www_authenticate_header_for_invalid_token():
+    client = _build_client()
+
+    response = client.post(
+        "/auth/logout",
+        headers={"Authorization": "Bearer not-a-jwt"},
+    )
+
+    assert response.headers.get("www-authenticate") == "Bearer"
+
+
+@pytest.mark.parametrize("user_id", [1, 2, 3, 7, 11, 42, 99, 123, 1000, 9999])
+def test_logout_returns_200_for_valid_token(user_id: int):
+    client = _build_client()
+    token = create_access_token(user_id=user_id)
+
+    response = client.post(
+        "/auth/logout",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+
+
+def test_logout_returns_success_message_for_valid_token():
+    client = _build_client()
+    token = create_access_token(user_id=1)
+
+    response = client.post(
+        "/auth/logout",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.json()["detail"] == "Logged out successfully"
+
+
+def test_logout_marks_token_as_revoked_after_success():
+    client = _build_client()
+    token = create_access_token(user_id=1)
+
+    before = is_access_token_revoked(token)
+    response = client.post(
+        "/auth/logout",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    after = is_access_token_revoked(token)
+
+    assert before is False
+    assert response.status_code == 200
+    assert after is True
+
+
+@pytest.mark.parametrize("user_id", [1, 2, 3, 4, 5])
+def test_logout_is_idempotent_for_same_token(user_id: int):
+    client = _build_client()
+    token = create_access_token(user_id=user_id)
+
+    first = client.post(
+        "/auth/logout",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    second = client.post(
+        "/auth/logout",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+
+
+def test_logout_only_revokes_provided_token_not_another_token():
+    client = _build_client()
+    token_one = create_access_token(user_id=1)
+    token_two = create_access_token(user_id=1)
+
+    client.post(
+        "/auth/logout",
+        headers={"Authorization": f"Bearer {token_one}"},
+    )
+
+    assert is_access_token_revoked(token_one) is True
+    assert is_access_token_revoked(token_two) is False
+
+
+@pytest.mark.parametrize("pair", [(1, 2), (5, 6), (10, 11)])
+def test_logout_revocation_is_isolated_between_multiple_tokens(pair: tuple[int, int]):
+    client = _build_client()
+    first_id, second_id = pair
+    token_one = create_access_token(user_id=first_id)
+    token_two = create_access_token(user_id=second_id)
+
+    client.post(
+        "/auth/logout",
+        headers={"Authorization": f"Bearer {token_two}"},
+    )
+
+    assert is_access_token_revoked(token_two) is True
+    assert is_access_token_revoked(token_one) is False
+
+
+def test_logout_accepts_token_encoded_with_current_secret():
+    payload = _valid_payload(sub="7")
+    token = _encode_payload(payload)
+    client = _build_client()
+    response = client.post(
+        "/auth/logout",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"sub": "1", "iat": 1_700_000_000, "exp": 2_000_000_000},
+        {"sub": "1", "jti": "", "iat": 1_700_000_000, "exp": 2_000_000_000},
+        {"sub": "1", "jti": None, "iat": 1_700_000_000, "exp": 2_000_000_000},
+    ],
+)
+def test_logout_rejects_token_with_missing_or_invalid_jti_claim(payload: dict):
+    token = _encode_payload(payload)
+    client = _build_client()
+
+    response = client.post(
+        "/auth/logout",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid access token"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"sub": "1", "jti": "abc", "iat": 1_700_000_000},
+        {"sub": "1", "jti": "abc", "iat": 1_700_000_000, "exp": "tomorrow"},
+        {"sub": "1", "jti": "abc", "iat": 1_700_000_000, "exp": 1.25},
+        {"sub": "1", "jti": "abc", "iat": 1_700_000_000, "exp": None},
+        {"sub": "1", "jti": "abc", "iat": 1_700_000_000, "exp": []},
+        {"sub": "1", "jti": "abc", "iat": 1_700_000_000, "exp": {}},
+    ],
+)
+def test_logout_rejects_token_with_missing_or_invalid_exp_claim(payload: dict):
+    token = _encode_payload(payload)
+    client = _build_client()
+
+    response = client.post(
+        "/auth/logout",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid access token"
+
+
+@pytest.mark.parametrize("verify_exp", [True, False])
+def test_decode_access_token_returns_payload_for_valid_token(verify_exp: bool):
+    token = create_access_token(user_id=33)
+
+    payload = decode_access_token(token, verify_exp=verify_exp)
+    assert payload["sub"] == "33"
+    assert "jti" in payload
+    assert "exp" in payload
+
+
+def test_decode_access_token_raises_for_expired_token_when_verify_exp_true():
+    expired_payload = {
+        "sub": "1",
+        "jti": str(uuid4()),
+        "iat": 1,
+        "exp": 2,
+    }
+    expired_token = _encode_payload(expired_payload)
+
+    with pytest.raises(jwt.InvalidTokenError):
+        decode_access_token(expired_token, verify_exp=True)
+
+
+def test_decode_access_token_without_exp_verification_allows_expired_token():
+    expired_payload = {
+        "sub": "1",
+        "jti": str(uuid4()),
+        "iat": 1,
+        "exp": 2,
+    }
+    expired_token = _encode_payload(expired_payload)
+
+    decoded = decode_access_token(expired_token, verify_exp=False)
+    assert decoded["jti"] == expired_payload["jti"]
+
+
+@pytest.mark.parametrize("iterations", [1, 2, 3, 5])
+def test_logout_multiple_tokens_for_same_user_are_independently_revoked(iterations: int):
+    client = _build_client()
+    tokens = [create_access_token(user_id=5) for _ in range(iterations)]
+
+    for token in tokens:
+        response = client.post(
+            "/auth/logout",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+
+    for token in tokens:
+        assert is_access_token_revoked(token) is True

--- a/backend/tests/test_auth_api_signup.py
+++ b/backend/tests/test_auth_api_signup.py
@@ -1,0 +1,511 @@
+import asyncio
+import os
+from datetime import datetime
+from typing import Optional
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Ensure settings can be instantiated when importing app.auth.api.
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_DB", "test")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+
+from app.auth import api as auth_api
+from app.auth.schemas import User, UserCreate
+
+
+NOW = datetime(2026, 4, 12, 10, 30, 0)
+
+
+class FakeAuthService:
+    def __init__(self, *, user_to_return: Optional[User] = None, error_to_raise: Optional[Exception] = None):
+        """Initialize a configurable fake auth service for signup tests.
+
+        :param user_to_return: User instance returned by ``register`` when no
+            error is configured.
+        :param error_to_raise: Exception raised by ``register`` to test error
+            mapping behavior.
+        :return: None.
+        """
+        self.user_to_return = user_to_return
+        self.error_to_raise = error_to_raise
+        self.register_calls = 0
+        self.last_register_payload: Optional[UserCreate] = None
+
+    async def register(self, user_data: UserCreate) -> User:
+        """Simulate signup registration behavior for unit tests.
+
+        The method records invocation metadata so tests can assert delegation
+        behavior and payload forwarding from the API layer.
+
+        :param user_data: Signup payload received by the fake service.
+        :return: Preconfigured user instance when no error is configured.
+        :raises Exception: Re-raises the configured ``error_to_raise`` when
+            present.
+        """
+        self.register_calls += 1
+        self.last_register_payload = user_data
+        if self.error_to_raise is not None:
+            raise self.error_to_raise
+        return self.user_to_return
+
+
+def _build_user(
+    *,
+    user_id: int = 1,
+    username: str = "alice",
+    email: str = "alice@example.com",
+    github_page: Optional[str] = None,
+    bio: Optional[str] = None,
+) -> User:
+    """Create a deterministic user fixture for signup endpoint tests.
+
+    :param user_id: Identifier assigned to the returned user model.
+    :param username: Username assigned to the returned user model.
+    :param email: Email assigned to the returned user model.
+    :param github_page: Optional GitHub profile URL assigned to the user.
+    :param bio: Optional user biography text.
+    :return: A fully populated ``User`` instance with stable timestamps.
+    """
+    return User(
+        id=user_id,
+        username=username,
+        email=email,
+        github_page=github_page,
+        bio=bio,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _build_client(
+    fake_service: FakeAuthService,
+    *,
+    raise_server_exceptions: bool = True,
+) -> TestClient:
+    """Build a FastAPI test client with auth service dependency overridden.
+
+    :param fake_service: Fake service injected into the auth router
+        dependency graph.
+    :return: Configured ``TestClient`` ready for signup endpoint tests.
+    """
+    app = FastAPI()
+    app.include_router(auth_api.router)
+    app.dependency_overrides[auth_api.get_auth_service] = lambda: fake_service
+    return TestClient(app, raise_server_exceptions=raise_server_exceptions)
+
+
+def test_signup_returns_201_on_success_with_required_fields_only():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/signup",
+        json={
+            "username": "alice",
+            "email": "alice@example.com",
+            "password": "plain-password",
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.json()["username"] == "alice"
+    assert response.json()["email"] == "alice@example.com"
+
+
+def test_signup_returns_201_on_success_with_optional_fields():
+    fake_service = FakeAuthService(
+        user_to_return=_build_user(
+            github_page="https://github.com/alice",
+            bio="Open-source contributor",
+        )
+    )
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/signup",
+        json={
+            "username": "alice",
+            "email": "alice@example.com",
+            "password": "plain-password",
+            "github_page": "https://github.com/alice",
+            "bio": "Open-source contributor",
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.json()["bio"] == "Open-source contributor"
+    assert response.json()["github_page"] == "https://github.com/alice"
+
+
+def test_signup_response_does_not_expose_password_field():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/signup",
+        json={
+            "username": "alice",
+            "email": "alice@example.com",
+            "password": "plain-password",
+        },
+    )
+
+    assert response.status_code == 201
+    assert "password" not in response.json()
+
+
+def test_signup_calls_register_once_on_success():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/signup",
+        json={
+            "username": "alice",
+            "email": "alice@example.com",
+            "password": "plain-password",
+        },
+    )
+
+    assert response.status_code == 201
+    assert fake_service.register_calls == 1
+
+
+def test_signup_passes_expected_payload_to_service_register():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    request_payload = {
+        "username": "alice",
+        "email": "alice@example.com",
+        "password": "plain-password",
+        "github_page": "https://github.com/alice",
+        "bio": "bio text",
+    }
+    response = client.post("/auth/signup", json=request_payload)
+
+    assert response.status_code == 201
+    assert fake_service.last_register_payload is not None
+    assert fake_service.last_register_payload.username == "alice"
+    assert str(fake_service.last_register_payload.email) == "alice@example.com"
+    assert fake_service.last_register_payload.password == "plain-password"
+    assert str(fake_service.last_register_payload.github_page) == "https://github.com/alice"
+    assert fake_service.last_register_payload.bio == "bio text"
+
+
+def test_signup_maps_duplicate_email_to_conflict_409():
+    fake_service = FakeAuthService(error_to_raise=ValueError("Email already exists"))
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/signup",
+        json={
+            "username": "alice",
+            "email": "alice@example.com",
+            "password": "plain-password",
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Email already exists"
+
+
+def test_signup_preserves_value_error_message_in_response_detail():
+    fake_service = FakeAuthService(error_to_raise=ValueError("Custom signup rule failed"))
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/signup",
+        json={
+            "username": "alice",
+            "email": "alice@example.com",
+            "password": "plain-password",
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Custom signup rule failed"
+
+
+def test_signup_returns_422_for_empty_json_body():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post("/auth/signup", json={})
+
+    assert response.status_code == 422
+
+
+def test_signup_returns_422_when_username_is_missing():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/signup",
+        json={"email": "alice@example.com", "password": "plain-password"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_signup_returns_422_when_email_is_missing():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/signup",
+        json={"username": "alice", "password": "plain-password"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_signup_returns_422_when_password_is_missing():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/signup",
+        json={"username": "alice", "email": "alice@example.com"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_signup_returns_422_for_invalid_email_format():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/signup",
+        json={
+            "username": "alice",
+            "email": "invalid-email",
+            "password": "plain-password",
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_signup_returns_422_for_invalid_github_url():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/signup",
+        json={
+            "username": "alice",
+            "email": "alice@example.com",
+            "password": "plain-password",
+            "github_page": "not-a-url",
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_signup_returns_422_for_empty_username():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/signup",
+        json={
+            "username": "",
+            "email": "alice@example.com",
+            "password": "plain-password",
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_signup_returns_422_for_username_longer_than_255():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/signup",
+        json={
+            "username": "a" * 256,
+            "email": "alice@example.com",
+            "password": "plain-password",
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_signup_returns_422_for_empty_password():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/signup",
+        json={
+            "username": "alice",
+            "email": "alice@example.com",
+            "password": "",
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_signup_returns_422_for_password_longer_than_255():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/signup",
+        json={
+            "username": "alice",
+            "email": "alice@example.com",
+            "password": "p" * 256,
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_signup_returns_created_user_identifier_and_timestamps():
+    fake_service = FakeAuthService(user_to_return=_build_user(user_id=42))
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/signup",
+        json={
+            "username": "alice",
+            "email": "alice@example.com",
+            "password": "plain-password",
+        },
+    )
+
+    body = response.json()
+    assert response.status_code == 201
+    assert body["id"] == 42
+    assert body["created_at"].startswith("2026-04-12T10:30:00")
+    assert body["updated_at"].startswith("2026-04-12T10:30:00")
+
+
+def test_signup_route_function_returns_user_object_on_success():
+    async def run_test():
+        fake_service = FakeAuthService(user_to_return=_build_user(user_id=7))
+        payload = UserCreate(
+            username="alice",
+            email="alice@example.com",
+            password="plain-password",
+        )
+
+        result = await auth_api.signup(payload, fake_service)
+
+        assert result.id == 7
+        assert result.email == "alice@example.com"
+
+    asyncio.run(run_test())
+
+
+def test_signup_route_function_raises_http_409_for_value_error():
+    async def run_test():
+        fake_service = FakeAuthService(error_to_raise=ValueError("Email already exists"))
+        payload = UserCreate(
+            username="alice",
+            email="alice@example.com",
+            password="plain-password",
+        )
+
+        try:
+            await auth_api.signup(payload, fake_service)
+            raise AssertionError("Expected HTTPException for duplicate email")
+        except Exception as exc:  # noqa: BLE001 - explicit behavior assertion.
+            assert exc.status_code == 409
+            assert exc.detail == "Email already exists"
+
+    asyncio.run(run_test())
+
+
+def test_signup_does_not_map_unexpected_service_error_to_409():
+    fake_service = FakeAuthService(error_to_raise=RuntimeError("unexpected failure"))
+    client = _build_client(fake_service, raise_server_exceptions=False)
+
+    response = client.post(
+        "/auth/signup",
+        json={
+            "username": "alice",
+            "email": "alice@example.com",
+            "password": "plain-password",
+        },
+    )
+
+    assert response.status_code == 500
+
+
+def test_signup_validation_error_short_circuits_service_register_call():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/signup",
+        json={
+            "username": "",
+            "email": "alice@example.com",
+            "password": "plain-password",
+        },
+    )
+
+    assert response.status_code == 422
+    assert fake_service.register_calls == 0
+
+
+def test_signup_returns_500_when_service_returns_invalid_response_model():
+    fake_service = FakeAuthService(user_to_return=None)
+    client = _build_client(fake_service, raise_server_exceptions=False)
+
+    response = client.post(
+        "/auth/signup",
+        json={
+            "username": "alice",
+            "email": "alice@example.com",
+            "password": "plain-password",
+        },
+    )
+
+    assert response.status_code == 500
+
+
+def test_signup_returns_422_for_malformed_json_body():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/signup",
+        content='{"username": "alice", "email": "alice@example.com",',
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 422
+    assert fake_service.register_calls == 0
+
+
+def test_signup_ignores_extra_input_fields_by_contract():
+    fake_service = FakeAuthService(user_to_return=_build_user())
+    client = _build_client(fake_service)
+
+    response = client.post(
+        "/auth/signup",
+        json={
+            "username": "alice",
+            "email": "alice@example.com",
+            "password": "plain-password",
+            "unexpected_field": "should be ignored",
+        },
+    )
+
+    assert response.status_code == 201
+    assert fake_service.last_register_payload is not None
+    assert "unexpected_field" not in fake_service.last_register_payload.model_dump()


### PR DESCRIPTION
### Implement the auth/signup endpoint

Refer to #21

This pull-request refer to the signup route of the auth package, it makes use of the AuthService for signing up purpose, also the UserCreate schema.

#### Implemented
- Wire signup route to AuthLocalService via FastAPI dependency injection
- Introduce get_db_session and get_auth_service dependency factories
- Simplify get_db_session to use db_engine.async_session() directly
- Map ValueError (duplicate email) to HTTP 409 Conflict
- Add explicit Python docstrings with :param:/:return:/:raises: style

#### Tests
- 25 unit tests covering success path, 409 conflict, 422 validation failures, service delegation, response schema enforcement, unexpected error passthrough, malformed JSON, and extra field handling
- FakeAuthService for service-layer isolation without DB