### PR TITLE
feat(api): implement POST /projects creation

### DIFF
--- a/backend/app/projects/api.py
+++ b/backend/app/projects/api.py
@@ -4,18 +4,71 @@ Project API routes: CRUD operations for projects.
 All routes delegate to ProjectService for business logic.
 """
 
-from fastapi import APIRouter
+from typing import AsyncGenerator
 
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.settings import settings
+from app.db.session import DatabaseEngine
 from app.projects.schemas import Project, ProjectCreate
+from app.projects.service import ProjectService
+from app.projects.sql_repository import SqlRepository
+from app.projects.sql_service import SQLProjectService
+from app.projects.exception import CreateProjectError
 
 
 router = APIRouter(prefix="/projects", tags=["projects"])
 
+_db_engine = DatabaseEngine(database_url=settings.db_url)
 
-@router.post("/", response_model=Project)
-async def create_project(project_data: ProjectCreate):
-    """Create a new project."""
-    raise NotImplementedError
+
+async def get_db_session() -> AsyncGenerator[AsyncSession, None]:
+    """Yield an async database session for project route dependencies."""
+    async with _db_engine.async_session() as session:
+        yield session
+
+
+def get_project_service(session: AsyncSession = Depends(get_db_session)) -> ProjectService:
+    """Build the project service used by route handlers."""
+    return SQLProjectService(SqlRepository(session))
+
+
+@router.post("/", response_model=Project, status_code=status.HTTP_201_CREATED)
+async def create_project(
+    project_data: ProjectCreate,
+    project_service: ProjectService = Depends(get_project_service),
+):
+    """
+    Create a new project.
+
+    This endpoint validates the incoming request body, delegates the creation
+    logic to the project service, and returns the created project using an
+    HTTP 201 Created response.
+
+    Args:
+        project_data: Validated payload containing the project fields to
+            persist.
+        project_service: Request-scoped service responsible for project
+            creation business rules.
+
+    Returns:
+        The created project, including database-generated fields such as the
+        identifier and timestamps.
+
+    Raises:
+        HTTPException: Returns a 409 Conflict response when project creation
+            fails due to a business constraint such as a duplicate repository
+            URL.
+    """
+    try:
+        return await project_service.create(project_data=project_data)
+    except CreateProjectError as cpe:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(cpe)
+        )
+
 
 
 @router.get("/", response_model=list[Project])

--- a/backend/app/projects/sql_repository.py
+++ b/backend/app/projects/sql_repository.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from app.projects.repository import ProjectRepository
 from app.projects.schemas import Project, ProjectCreate
 from app.db.models import Project as ProjectModel
+from app.projects.exception import CreateProjectError
 from sqlmodel import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,25 +20,29 @@ class SqlRepository(ProjectRepository):
         """
         self.session = session
     
-    async def create(self, project_data: ProjectCreate):
+    async def create(self, project_data: ProjectCreate) -> Project:
         """
         Creates a new project in the database.
 
         Args:
             project_data: The data for the new project.
 
+        Returns:
+            The created project with database-generated fields populated.
+
         Raises:
-            Exception: If the project could not be created.
+            CreateProjectError: If the project could not be created.
         """
         project_model = ProjectModel(**project_data.model_dump())
         self.session.add(project_model)
         try:
             await self.session.commit()
             await self.session.refresh(project_model)
-        except Exception:
+            return Project.model_validate(project_model)
+        except Exception as exc:
             await self.session.rollback()
-            raise
-    
+            raise CreateProjectError(f'''Cannot create the project {project_model}''') from exc
+
     async def get_by_id(self, project_id: int) -> Project | None:
         """
         Retrieves a project by its ID.

--- a/backend/tests/test_api_projects.py
+++ b/backend/tests/test_api_projects.py
@@ -1,0 +1,233 @@
+import os
+from datetime import datetime
+from typing import Optional
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_DB", "test")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+os.environ.setdefault("JWT_SECRET_KEY", "test-jwt-secret-key-at-least-32-bytes")
+os.environ.setdefault("JWT_ALGORITHM", "HS256")
+os.environ.setdefault("JWT_EXPIRATION_MINUTES", "30")
+
+from app.projects import api as projects_api
+from app.projects.schemas import Project, ProjectCreate
+from app.projects.exception import CreateProjectError
+
+
+NOW = datetime(2026, 4, 17, 10, 0, 0)
+
+VALID_PAYLOAD = {
+    "title": "My OSS Project",
+    "description": "An open source project",
+    "repository_url": "https://github.com/example/project",
+    "help_wanted": False,
+}
+
+
+class FakeProjectService:
+    def __init__(
+        self,
+        *,
+        project_to_return: Optional[Project] = None,
+        error_to_raise: Optional[Exception] = None,
+    ):
+        self.project_to_return = project_to_return
+        self.error_to_raise = error_to_raise
+        self.create_calls = 0
+        self.last_project_data: Optional[ProjectCreate] = None
+
+    async def create(self, project_data: ProjectCreate) -> Project:
+        self.create_calls += 1
+        self.last_project_data = project_data
+        if self.error_to_raise is not None:
+            raise self.error_to_raise
+        return self.project_to_return
+
+
+def _build_project(
+    *,
+    project_id: int = 1,
+    title: str = VALID_PAYLOAD["title"],
+    description: str = VALID_PAYLOAD["description"],
+    repository_url: str = VALID_PAYLOAD["repository_url"],
+    help_wanted: bool = VALID_PAYLOAD["help_wanted"],
+) -> Project:
+    return Project(
+        id=project_id,
+        title=title,
+        description=description,
+        repository_url=repository_url,
+        help_wanted=help_wanted,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _build_client(
+    fake_service: FakeProjectService,
+    *,
+    raise_server_exceptions: bool = True,
+) -> TestClient:
+    app = FastAPI()
+    app.include_router(projects_api.router)
+    app.dependency_overrides[projects_api.get_project_service] = lambda: fake_service
+    return TestClient(app, raise_server_exceptions=raise_server_exceptions)
+
+
+# ---------------------------------------------------------------------------
+# Success path
+# ---------------------------------------------------------------------------
+
+def test_create_project_returns_201_on_success():
+    fake_service = FakeProjectService(project_to_return=_build_project())
+    client = _build_client(fake_service)
+
+    response = client.post("/projects/", json=VALID_PAYLOAD)
+
+    assert response.status_code == 201
+
+
+def test_create_project_response_contains_project_id():
+    fake_service = FakeProjectService(project_to_return=_build_project(project_id=42))
+    client = _build_client(fake_service)
+
+    response = client.post("/projects/", json=VALID_PAYLOAD)
+
+    assert response.json()["id"] == 42
+
+
+def test_create_project_response_contains_title():
+    fake_service = FakeProjectService(project_to_return=_build_project())
+    client = _build_client(fake_service)
+
+    response = client.post("/projects/", json=VALID_PAYLOAD)
+
+    assert response.json()["title"] == VALID_PAYLOAD["title"]
+
+
+def test_create_project_response_contains_repository_url():
+    fake_service = FakeProjectService(project_to_return=_build_project())
+    client = _build_client(fake_service)
+
+    response = client.post("/projects/", json=VALID_PAYLOAD)
+
+    assert response.json()["repository_url"] == VALID_PAYLOAD["repository_url"]
+
+
+def test_create_project_response_contains_help_wanted():
+    fake_service = FakeProjectService(project_to_return=_build_project())
+    client = _build_client(fake_service)
+
+    response = client.post("/projects/", json=VALID_PAYLOAD)
+
+    assert response.json()["help_wanted"] == VALID_PAYLOAD["help_wanted"]
+
+
+def test_create_project_delegates_to_service():
+    fake_service = FakeProjectService(project_to_return=_build_project())
+    client = _build_client(fake_service)
+
+    client.post("/projects/", json=VALID_PAYLOAD)
+
+    assert fake_service.create_calls == 1
+
+
+def test_create_project_forwards_title_to_service():
+    fake_service = FakeProjectService(project_to_return=_build_project())
+    client = _build_client(fake_service)
+
+    client.post("/projects/", json=VALID_PAYLOAD)
+
+    assert fake_service.last_project_data.title == VALID_PAYLOAD["title"]
+
+
+def test_create_project_forwards_repository_url_to_service():
+    fake_service = FakeProjectService(project_to_return=_build_project())
+    client = _build_client(fake_service)
+
+    client.post("/projects/", json=VALID_PAYLOAD)
+
+    assert str(fake_service.last_project_data.repository_url) == VALID_PAYLOAD["repository_url"]
+
+
+def test_create_project_forwards_help_wanted_to_service():
+    fake_service = FakeProjectService(project_to_return=_build_project(help_wanted=True))
+    client = _build_client(fake_service)
+
+    payload = {**VALID_PAYLOAD, "help_wanted": True}
+    client.post("/projects/", json=payload)
+
+    assert fake_service.last_project_data.help_wanted is True
+
+
+# ---------------------------------------------------------------------------
+# Conflict path
+# ---------------------------------------------------------------------------
+
+def test_create_project_returns_409_on_create_project_error():
+    fake_service = FakeProjectService(
+        error_to_raise=CreateProjectError("A project with that URL already exists.")
+    )
+    client = _build_client(fake_service)
+
+    response = client.post("/projects/", json=VALID_PAYLOAD)
+
+    assert response.status_code == 409
+
+
+def test_create_project_409_response_contains_error_detail():
+    error_message = "A project with that URL already exists."
+    fake_service = FakeProjectService(error_to_raise=CreateProjectError(error_message))
+    client = _build_client(fake_service)
+
+    response = client.post("/projects/", json=VALID_PAYLOAD)
+
+    assert response.json()["detail"] == error_message
+
+
+def test_create_project_does_not_swallow_unexpected_errors():
+    fake_service = FakeProjectService(error_to_raise=RuntimeError("unexpected"))
+    client = _build_client(fake_service, raise_server_exceptions=False)
+
+    response = client.post("/projects/", json=VALID_PAYLOAD)
+
+    assert response.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# Validation path
+# ---------------------------------------------------------------------------
+
+def test_create_project_returns_422_when_title_is_missing():
+    fake_service = FakeProjectService(project_to_return=_build_project())
+    client = _build_client(fake_service)
+
+    payload = {k: v for k, v in VALID_PAYLOAD.items() if k != "title"}
+    response = client.post("/projects/", json=payload)
+
+    assert response.status_code == 422
+
+
+def test_create_project_returns_422_when_repository_url_is_invalid():
+    fake_service = FakeProjectService(project_to_return=_build_project())
+    client = _build_client(fake_service)
+
+    payload = {**VALID_PAYLOAD, "repository_url": "not-a-url"}
+    response = client.post("/projects/", json=payload)
+
+    assert response.status_code == 422
+
+
+def test_create_project_returns_422_when_title_is_empty_string():
+    fake_service = FakeProjectService(project_to_return=_build_project())
+    client = _build_client(fake_service)
+
+    payload = {**VALID_PAYLOAD, "title": ""}
+    response = client.post("/projects/", json=payload)
+
+    assert response.status_code == 422

--- a/backend/tests/test_project_sql_repository.py
+++ b/backend/tests/test_project_sql_repository.py
@@ -1,3 +1,4 @@
+from app.projects.exception import CreateProjectError
 import asyncio
 from datetime import datetime
 import pytest
@@ -23,6 +24,17 @@ def make_repository(session: AsyncMock | None = None) -> SqlRepository:
     return SqlRepository(session=session or make_session())
 
 
+def configure_refresh_with_db_defaults(session: AsyncMock) -> None:
+    """Simulate database-generated fields populated during refresh."""
+
+    async def refresh_side_effect(model: ProjectModel) -> None:
+        model.id = 1
+        model.created_at = DT
+        model.updated_at = DT
+
+    session.refresh.side_effect = refresh_side_effect
+
+
 # ---------------------------------------------------------------------------
 # create
 # ---------------------------------------------------------------------------
@@ -30,6 +42,7 @@ def make_repository(session: AsyncMock | None = None) -> SqlRepository:
 def test_create_project_success():
     """Test successful creation of a project."""
     session = make_session()
+    configure_refresh_with_db_defaults(session)
     repo = make_repository(session)
     project_data = ProjectCreate(
         title="Test Project",
@@ -60,8 +73,10 @@ def test_create_project_commit_fails():
     )
 
     async def run():
-        with pytest.raises(Exception, match="Commit failed"):
+        with pytest.raises(CreateProjectError, match="Cannot create the project") as exc_info:
             await repo.create(project_data)
+        assert exc_info.value.__cause__ is not None
+        assert str(exc_info.value.__cause__) == "Commit failed"
 
     asyncio.run(run())
 
@@ -74,6 +89,7 @@ def test_create_project_commit_fails():
 def test_create_project_with_minimal_data():
     """Test creating a project with only the required fields."""
     session = make_session()
+    configure_refresh_with_db_defaults(session)
     repo = make_repository(session)
     project_data = ProjectCreate(
         title="Minimal Project",
@@ -97,6 +113,7 @@ def test_create_project_with_minimal_data():
 def test_create_project_passes_all_fields_to_model():
     """Test that all fields from ProjectCreate are forwarded to the db model."""
     session = make_session()
+    configure_refresh_with_db_defaults(session)
     repo = make_repository(session)
     project_data = ProjectCreate(
         title="Full Project",
@@ -119,6 +136,7 @@ def test_create_project_passes_all_fields_to_model():
 def test_create_calls_add_before_commit():
     """Test that add is called before commit during creation."""
     session = make_session()
+    configure_refresh_with_db_defaults(session)
     repo = make_repository(session)
     project_data = ProjectCreate(
         title="Order Test",


### PR DESCRIPTION
# Implement the POST for /project endpoint

## Close #31 

- Create a new project.

- Validate the incoming request body, delegate the creation logic to the project service, and return the created project using an HTTP 201 Created response.

- Return HTTP 409 Conflict when project creation fails due to a business constraint such as a duplicate repository URL.

- Also return the created project from the repository after commit and refresh, and update the API and repository tests accordingly.