### PR TITLE
Feature/retrieve all projects

### DIFF
--- a/backend/app/projects/api.py
+++ b/backend/app/projects/api.py
@@ -6,7 +6,7 @@ All routes delegate to ProjectService for business logic.
 
 from typing import AsyncGenerator
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.settings import settings
@@ -74,8 +74,8 @@ async def create_project(
 
 @router.get("/", response_model=list[Project])
 async def list_projects(
-    skip: int = 0,
-    limit: int = 100,
+    skip: int = Query(default=0, ge=0),
+    limit: int = Query(default=100, ge=1, le=1000),
     project_service: ProjectService = Depends(get_project_service),
 ):
     """
@@ -98,8 +98,8 @@ async def list_projects(
 
 @router.get("/help-wanted", response_model=list[Project])
 async def list_help_wanted_projects(
-    skip: int = 0,
-    limit: int = 100,
+    skip: int = Query(default=0, ge=0),
+    limit: int = Query(default=100, ge=1, le=1000),
     project_service: ProjectService = Depends(get_project_service),
 ):
     """

--- a/backend/app/projects/api.py
+++ b/backend/app/projects/api.py
@@ -16,6 +16,7 @@ from app.projects.service import ProjectService
 from app.projects.sql_repository import SqlRepository
 from app.projects.sql_service import SQLProjectService
 from app.projects.exception import CreateProjectError
+from app.projects.exception import ProjectNotFoundError
 
 
 router = APIRouter(prefix="/projects", tags=["projects"])
@@ -72,18 +73,80 @@ async def create_project(
 
 
 @router.get("/", response_model=list[Project])
-async def list_projects(skip: int = 0, limit: int = 100):
-    """List all projects."""
-    raise NotImplementedError
+async def list_projects(
+    skip: int = 0,
+    limit: int = 100,
+    project_service: ProjectService = Depends(get_project_service),
+):
+    """
+    List projects with optional pagination.
 
+    This endpoint delegates project retrieval to the project service and
+    returns a paginated list of stored projects.
 
-@router.get("/{project_id}", response_model=Project)
-async def get_project(project_id: int):
-    """Get a single project by ID."""
-    raise NotImplementedError
+    Args:
+        skip: Number of project records to skip before returning results.
+        limit: Maximum number of project records to include in the response.
+        project_service: Request-scoped service responsible for project
+            listing operations.
+
+    Returns:
+        A list of projects matching the requested pagination parameters.
+    """
+    return await project_service.list(skip=skip, limit=limit)
 
 
 @router.get("/help-wanted", response_model=list[Project])
-async def list_help_wanted_projects():
-    """List projects seeking help."""
-    raise NotImplementedError
+async def list_help_wanted_projects(
+    skip: int = 0,
+    limit: int = 100,
+    project_service: ProjectService = Depends(get_project_service),
+):
+    """
+    List projects currently marked as seeking help.
+
+    This endpoint delegates filtering to the project service and returns only
+    projects where the ``help_wanted`` flag is set to ``True``.
+
+    Args:
+        skip: Number of help-wanted project records to skip.
+        limit: Maximum number of help-wanted project records to include.
+        project_service: Request-scoped service responsible for help-wanted
+            listing operations.
+
+    Returns:
+        A list of projects flagged as help wanted.
+    """
+    return await project_service.list_help_wanted(skip=skip, limit=limit)
+
+
+@router.get("/{project_id}", response_model=Project)
+async def get_project(
+    project_id: int,
+    project_service: ProjectService = Depends(get_project_service),
+):
+    """
+    Get a single project by its identifier.
+
+    This endpoint delegates lookup to the project service and returns the
+    matching project when found.
+
+    Args:
+        project_id: Identifier of the project to retrieve.
+        project_service: Request-scoped service responsible for project
+            retrieval operations.
+
+    Returns:
+        The project matching the provided id.
+
+    Raises:
+        HTTPException: Returns a 404 Not Found response when no project exists
+            for the given id.
+    """
+    try:
+        return await project_service.get_by_id(project_id=project_id)
+    except ProjectNotFoundError as pnfe:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(pnfe),
+        )

--- a/backend/app/projects/repository.py
+++ b/backend/app/projects/repository.py
@@ -70,8 +70,12 @@ class ProjectRepository(ABC):
         raise NotImplementedError
     
     @abstractmethod
-    async def list_help_wanted(self) -> List[Project]:
-        """Return all projects currently marked as accepting help.
+    async def list_help_wanted(self, skip: int = 0, limit: int = 100) -> List[Project]:
+        """Return paginated projects currently marked as accepting help.
+
+        :param skip: Number of matching help-wanted project records to omit
+            before collecting results.
+        :param limit: Maximum number of help-wanted project records to return.
 
         :return: A list of project schemas whose ``help_wanted`` flag is set
             to ``True``.

--- a/backend/app/projects/service.py
+++ b/backend/app/projects/service.py
@@ -55,8 +55,12 @@ class ProjectService(ABC):
         ...
 
     @abstractmethod
-    async def list_help_wanted(self) -> List[Project]:
-        """List all projects that are flagged as looking for contributors.
+    async def list_help_wanted(self, skip: int = 0, limit: int = 100) -> List[Project]:
+        """List help-wanted projects with optional pagination.
+
+        Args:
+            skip: Number of records to skip before returning results. Defaults to 0.
+            limit: Maximum number of records to return. Defaults to 100.
 
         Returns:
             A list of projects where help_wanted is True.

--- a/backend/app/projects/sql_service.py
+++ b/backend/app/projects/sql_service.py
@@ -66,10 +66,14 @@ class SQLProjectService(ProjectService):
             raise ProjectNotFoundError(project_id)
         return project
 
-    async def list_help_wanted(self) -> List[Project]:
-        """List all projects that are flagged as looking for contributors.
+    async def list_help_wanted(self, skip: int = 0, limit: int = 100) -> List[Project]:
+        """List help-wanted projects with optional pagination.
+
+        Args:
+            skip: Number of records to skip before returning results. Defaults to 0.
+            limit: Maximum number of records to return. Defaults to 100.
 
         Returns:
             A list of projects where help_wanted is True.
         """
-        return await self.repository.list_help_wanted()
+        return await self.repository.list_help_wanted(skip=skip, limit=limit)

--- a/backend/tests/test_api_projects.py
+++ b/backend/tests/test_api_projects.py
@@ -443,3 +443,65 @@ def test_create_project_returns_422_when_title_is_empty_string():
     response = client.post("/projects/", json=payload)
 
     assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Pagination validation: list projects
+# ---------------------------------------------------------------------------
+
+def test_list_projects_returns_422_when_skip_is_negative():
+    fake_service = FakeProjectService(projects_to_return=[])
+    client = _build_client(fake_service)
+
+    response = client.get("/projects/?skip=-1")
+
+    assert response.status_code == 422
+
+
+def test_list_projects_returns_422_when_limit_is_zero():
+    fake_service = FakeProjectService(projects_to_return=[])
+    client = _build_client(fake_service)
+
+    response = client.get("/projects/?limit=0")
+
+    assert response.status_code == 422
+
+
+def test_list_projects_returns_422_when_limit_exceeds_maximum():
+    fake_service = FakeProjectService(projects_to_return=[])
+    client = _build_client(fake_service)
+
+    response = client.get("/projects/?limit=1001")
+
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Pagination validation: list help-wanted projects
+# ---------------------------------------------------------------------------
+
+def test_list_help_wanted_projects_returns_422_when_skip_is_negative():
+    fake_service = FakeProjectService(projects_to_return=[])
+    client = _build_client(fake_service)
+
+    response = client.get("/projects/help-wanted?skip=-1")
+
+    assert response.status_code == 422
+
+
+def test_list_help_wanted_projects_returns_422_when_limit_is_zero():
+    fake_service = FakeProjectService(projects_to_return=[])
+    client = _build_client(fake_service)
+
+    response = client.get("/projects/help-wanted?limit=0")
+
+    assert response.status_code == 422
+
+
+def test_list_help_wanted_projects_returns_422_when_limit_exceeds_maximum():
+    fake_service = FakeProjectService(projects_to_return=[])
+    client = _build_client(fake_service)
+
+    response = client.get("/projects/help-wanted?limit=1001")
+
+    assert response.status_code == 422

--- a/backend/tests/test_api_projects.py
+++ b/backend/tests/test_api_projects.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -17,6 +17,7 @@ os.environ.setdefault("JWT_EXPIRATION_MINUTES", "30")
 from app.projects import api as projects_api
 from app.projects.schemas import Project, ProjectCreate
 from app.projects.exception import CreateProjectError
+from app.projects.exception import ProjectNotFoundError
 
 
 NOW = datetime(2026, 4, 17, 10, 0, 0)
@@ -34,12 +35,24 @@ class FakeProjectService:
         self,
         *,
         project_to_return: Optional[Project] = None,
+        projects_to_return: Optional[List[Project]] = None,
+        all_projects: Optional[List[Project]] = None,
         error_to_raise: Optional[Exception] = None,
     ):
         self.project_to_return = project_to_return
+        self.projects_to_return = projects_to_return or []
+        self.all_projects = all_projects
         self.error_to_raise = error_to_raise
         self.create_calls = 0
+        self.list_calls = 0
+        self.list_help_wanted_calls = 0
+        self.get_by_id_calls = 0
         self.last_project_data: Optional[ProjectCreate] = None
+        self.last_skip: Optional[int] = None
+        self.last_limit: Optional[int] = None
+        self.last_help_wanted_skip: Optional[int] = None
+        self.last_help_wanted_limit: Optional[int] = None
+        self.last_project_id: Optional[int] = None
 
     async def create(self, project_data: ProjectCreate) -> Project:
         self.create_calls += 1
@@ -47,6 +60,33 @@ class FakeProjectService:
         if self.error_to_raise is not None:
             raise self.error_to_raise
         return self.project_to_return
+
+    async def list(self, skip: int = 0, limit: int = 100) -> List[Project]:
+        self.list_calls += 1
+        self.last_skip = skip
+        self.last_limit = limit
+        if self.error_to_raise is not None:
+            raise self.error_to_raise
+        if self.all_projects is not None:
+            return self.all_projects[skip:skip + limit]
+        return self.projects_to_return
+
+    async def get_by_id(self, project_id: int) -> Project:
+        self.get_by_id_calls += 1
+        self.last_project_id = project_id
+        if self.error_to_raise is not None:
+            raise self.error_to_raise
+        return self.project_to_return
+
+    async def list_help_wanted(self, skip: int = 0, limit: int = 100) -> List[Project]:
+        self.list_help_wanted_calls += 1
+        self.last_help_wanted_skip = skip
+        self.last_help_wanted_limit = limit
+        if self.error_to_raise is not None:
+            raise self.error_to_raise
+        if self.all_projects is not None:
+            return [project for project in self.all_projects if project.help_wanted][skip:skip + limit]
+        return [project for project in self.projects_to_return if project.help_wanted][skip:skip + limit]
 
 
 def _build_project(
@@ -82,6 +122,178 @@ def _build_client(
 # ---------------------------------------------------------------------------
 # Success path
 # ---------------------------------------------------------------------------
+
+def test_list_projects_returns_200_on_success():
+    fake_service = FakeProjectService(projects_to_return=[_build_project()])
+    client = _build_client(fake_service)
+
+    response = client.get("/projects/")
+
+    assert response.status_code == 200
+
+
+def test_list_projects_returns_projects_from_service():
+    fake_service = FakeProjectService(
+        projects_to_return=[
+            _build_project(project_id=1, title="Project One"),
+            _build_project(project_id=2, title="Project Two"),
+        ]
+    )
+    client = _build_client(fake_service)
+
+    response = client.get("/projects/")
+
+    assert [project["title"] for project in response.json()] == ["Project One", "Project Two"]
+
+
+def test_list_projects_delegates_to_service_once():
+    fake_service = FakeProjectService(projects_to_return=[])
+    client = _build_client(fake_service)
+
+    client.get("/projects/")
+
+    assert fake_service.list_calls == 1
+
+
+def test_list_projects_forwards_pagination_to_service():
+    fake_service = FakeProjectService(projects_to_return=[])
+    client = _build_client(fake_service)
+
+    client.get("/projects/?skip=5&limit=20")
+
+    assert fake_service.last_skip == 5
+    assert fake_service.last_limit == 20
+
+
+def test_list_projects_returns_paginated_subset_for_skip_and_limit():
+    fake_service = FakeProjectService(
+        all_projects=[
+            _build_project(project_id=1, title="Project One"),
+            _build_project(project_id=2, title="Project Two"),
+            _build_project(project_id=3, title="Project Three"),
+            _build_project(project_id=4, title="Project Four"),
+        ]
+    )
+    client = _build_client(fake_service)
+
+    response = client.get("/projects/?skip=1&limit=2")
+
+    assert [project["id"] for project in response.json()] == [2, 3]
+
+
+def test_list_projects_does_not_swallow_unexpected_errors():
+    fake_service = FakeProjectService(error_to_raise=RuntimeError("unexpected"))
+    client = _build_client(fake_service, raise_server_exceptions=False)
+
+    response = client.get("/projects/")
+
+    assert response.status_code == 500
+
+
+def test_get_project_returns_200_on_success():
+    fake_service = FakeProjectService(project_to_return=_build_project(project_id=7))
+    client = _build_client(fake_service)
+
+    response = client.get("/projects/7")
+
+    assert response.status_code == 200
+
+
+def test_get_project_returns_project_from_service():
+    fake_service = FakeProjectService(project_to_return=_build_project(project_id=7, title="Project Seven"))
+    client = _build_client(fake_service)
+
+    response = client.get("/projects/7")
+
+    assert response.json()["id"] == 7
+    assert response.json()["title"] == "Project Seven"
+
+
+def test_get_project_delegates_to_service_with_project_id():
+    fake_service = FakeProjectService(project_to_return=_build_project(project_id=99))
+    client = _build_client(fake_service)
+
+    client.get("/projects/99")
+
+    assert fake_service.get_by_id_calls == 1
+    assert fake_service.last_project_id == 99
+
+
+def test_get_project_returns_404_on_project_not_found_error():
+    fake_service = FakeProjectService(error_to_raise=ProjectNotFoundError(404))
+    client = _build_client(fake_service)
+
+    response = client.get("/projects/404")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Project with id 404 not found"
+
+
+def test_get_project_does_not_swallow_unexpected_errors():
+    fake_service = FakeProjectService(error_to_raise=RuntimeError("unexpected"))
+    client = _build_client(fake_service, raise_server_exceptions=False)
+
+    response = client.get("/projects/1")
+
+    assert response.status_code == 500
+
+
+def test_list_help_wanted_projects_returns_200_on_success():
+    fake_service = FakeProjectService(
+        projects_to_return=[
+            _build_project(project_id=1, title="Help One", help_wanted=True),
+            _build_project(project_id=2, title="Help Two", help_wanted=True),
+        ]
+    )
+    client = _build_client(fake_service)
+
+    response = client.get("/projects/help-wanted")
+
+    assert response.status_code == 200
+
+
+def test_list_help_wanted_projects_returns_only_help_wanted_entries():
+    fake_service = FakeProjectService(
+        all_projects=[
+            _build_project(project_id=1, title="Help One", help_wanted=True),
+            _build_project(project_id=2, title="Closed", help_wanted=False),
+            _build_project(project_id=3, title="Help Two", help_wanted=True),
+        ]
+    )
+    client = _build_client(fake_service)
+
+    response = client.get("/projects/help-wanted")
+
+    assert [project["id"] for project in response.json()] == [1, 3]
+    assert all(project["help_wanted"] for project in response.json())
+
+
+def test_list_help_wanted_projects_delegates_to_service_once():
+    fake_service = FakeProjectService(projects_to_return=[])
+    client = _build_client(fake_service)
+
+    client.get("/projects/help-wanted")
+
+    assert fake_service.list_help_wanted_calls == 1
+
+
+def test_list_help_wanted_projects_forwards_pagination_to_service():
+    fake_service = FakeProjectService(projects_to_return=[])
+    client = _build_client(fake_service)
+
+    client.get("/projects/help-wanted?skip=3&limit=4")
+
+    assert fake_service.last_help_wanted_skip == 3
+    assert fake_service.last_help_wanted_limit == 4
+
+
+def test_list_help_wanted_projects_does_not_swallow_unexpected_errors():
+    fake_service = FakeProjectService(error_to_raise=RuntimeError("unexpected"))
+    client = _build_client(fake_service, raise_server_exceptions=False)
+
+    response = client.get("/projects/help-wanted")
+
+    assert response.status_code == 500
 
 def test_create_project_returns_201_on_success():
     fake_service = FakeProjectService(project_to_return=_build_project())

--- a/backend/tests/test_db_models.py
+++ b/backend/tests/test_db_models.py
@@ -1,6 +1,6 @@
-from sqlmodel import SQLModel
-
+from app.domain.enums import ContributionStatus
 from app.db.models import Contribution, Project, User
+from sqlmodel import SQLModel
 
 
 def test_models_registered_in_metadata():
@@ -17,3 +17,185 @@ def test_models_registered_in_metadata():
     assert tables["user"].c["id"].primary_key
     assert tables["projects"].c["repository_url"].unique
     assert tables["contributions"].c["fk_user_id"].foreign_keys
+
+
+def test_user_table_has_expected_columns():
+    columns = set(SQLModel.metadata.tables["user"].c.keys())
+
+    assert columns == {
+        "id",
+        "username",
+        "email",
+        "password",
+        "github_page",
+        "bio",
+        "created_at",
+        "updated_at",
+    }
+
+
+def test_project_table_has_expected_columns():
+    columns = set(SQLModel.metadata.tables["projects"].c.keys())
+
+    assert columns == {
+        "id",
+        "title",
+        "description",
+        "repository_url",
+        "help_wanted",
+        "created_at",
+        "updated_at",
+    }
+
+
+def test_contribution_table_has_expected_columns():
+    columns = set(SQLModel.metadata.tables["contributions"].c.keys())
+
+    assert columns == {
+        "id",
+        "fk_user_id",
+        "fk_project_id",
+        "status",
+        "applied_at",
+        "updated_at",
+    }
+
+
+def test_user_primary_key_is_id():
+    user_table = SQLModel.metadata.tables["user"]
+
+    assert user_table.c["id"].primary_key is True
+
+
+def test_project_primary_key_is_id():
+    project_table = SQLModel.metadata.tables["projects"]
+
+    assert project_table.c["id"].primary_key is True
+
+
+def test_contribution_primary_key_is_id():
+    contribution_table = SQLModel.metadata.tables["contributions"]
+
+    assert contribution_table.c["id"].primary_key is True
+
+
+def test_user_email_is_unique_and_not_nullable():
+    email_column = SQLModel.metadata.tables["user"].c["email"]
+
+    assert email_column.unique is True
+    assert email_column.nullable is False
+
+
+def test_project_repository_url_is_unique_and_not_nullable():
+    repository_url_column = SQLModel.metadata.tables["projects"].c["repository_url"]
+
+    assert repository_url_column.unique is True
+    assert repository_url_column.nullable is False
+
+
+def test_help_wanted_is_boolean_not_nullable_column():
+    help_wanted_column = SQLModel.metadata.tables["projects"].c["help_wanted"]
+
+    assert help_wanted_column.nullable is False
+    assert help_wanted_column.type.python_type is bool
+
+
+def test_contribution_foreign_keys_target_user_and_project_tables():
+    contribution_table = SQLModel.metadata.tables["contributions"]
+    user_fk = next(iter(contribution_table.c["fk_user_id"].foreign_keys))
+    project_fk = next(iter(contribution_table.c["fk_project_id"].foreign_keys))
+
+    assert user_fk.target_fullname == "user.id"
+    assert project_fk.target_fullname == "projects.id"
+
+
+def test_contribution_foreign_keys_use_cascade_delete():
+    contribution_table = SQLModel.metadata.tables["contributions"]
+    user_fk = next(iter(contribution_table.c["fk_user_id"].foreign_keys))
+    project_fk = next(iter(contribution_table.c["fk_project_id"].foreign_keys))
+
+    assert user_fk.ondelete == "CASCADE"
+    assert project_fk.ondelete == "CASCADE"
+
+
+def test_user_timestamp_columns_have_server_defaults():
+    user_table = SQLModel.metadata.tables["user"]
+
+    assert user_table.c["created_at"].server_default is not None
+    assert user_table.c["updated_at"].server_default is not None
+
+
+def test_project_timestamp_columns_have_server_defaults():
+    project_table = SQLModel.metadata.tables["projects"]
+
+    assert project_table.c["created_at"].server_default is not None
+    assert project_table.c["updated_at"].server_default is not None
+
+
+def test_contribution_timestamp_columns_have_server_defaults():
+    contribution_table = SQLModel.metadata.tables["contributions"]
+
+    assert contribution_table.c["applied_at"].server_default is not None
+    assert contribution_table.c["updated_at"].server_default is not None
+
+
+def test_updated_at_columns_have_onupdate_callbacks():
+    user_updated = SQLModel.metadata.tables["user"].c["updated_at"]
+    project_updated = SQLModel.metadata.tables["projects"].c["updated_at"]
+    contribution_updated = SQLModel.metadata.tables["contributions"].c["updated_at"]
+
+    assert user_updated.onupdate is not None
+    assert project_updated.onupdate is not None
+    assert contribution_updated.onupdate is not None
+
+
+def test_contribution_status_has_interested_server_default():
+    status_column = SQLModel.metadata.tables["contributions"].c["status"]
+    default_sql = str(status_column.server_default.arg).lower()
+
+    assert status_column.nullable is False
+    assert ContributionStatus.INTERESTED.value in default_sql
+
+
+def test_user_contributions_relationship_back_populates_user():
+    relationship = User.contributions.property
+
+    assert relationship.back_populates == "user"
+
+
+def test_project_contributions_relationship_back_populates_project():
+    relationship = Project.contributions.property
+
+    assert relationship.back_populates == "project"
+
+
+def test_contribution_user_relationship_back_populates_contributions():
+    relationship = Contribution.user.property
+
+    assert relationship.back_populates == "contributions"
+
+
+def test_contribution_project_relationship_back_populates_contributions():
+    relationship = Contribution.project.property
+
+    assert relationship.back_populates == "contributions"
+
+
+def test_user_model_instantiation_sets_required_fields():
+    user = User(username="alice", email="alice@example.com", password="secret")
+
+    assert user.username == "alice"
+    assert user.email == "alice@example.com"
+    assert user.password == "secret"
+
+
+def test_project_model_instantiation_defaults_help_wanted_to_false():
+    project = Project(title="OSS", repository_url="https://github.com/example/oss")
+
+    assert project.help_wanted is False
+
+
+def test_contribution_model_instantiation_defaults_status_to_interested():
+    contribution = Contribution(fk_user_id=1, fk_project_id=1)
+
+    assert contribution.status == ContributionStatus.INTERESTED

--- a/backend/tests/test_db_session.py
+++ b/backend/tests/test_db_session.py
@@ -1,9 +1,13 @@
 import asyncio
 
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from app.db.session import DatabaseEngine
+
+
+def _sqlite_file_url(tmp_path) -> str:
+    return f"sqlite+aiosqlite:///{(tmp_path / 'test.db').as_posix()}"
 
 
 def test_database_engine_get_session_yields_async_session():
@@ -18,8 +22,76 @@ def test_database_engine_get_session_yields_async_session():
     asyncio.run(run_test())
 
 
-def test_database_engine_init_db_creates_tables():
+def test_database_engine_init_stores_database_url():
+    url = "sqlite+aiosqlite:///:memory:"
+    db_engine = DatabaseEngine(database_url=url)
+
+    assert db_engine.database_url == url
+
+
+def test_database_engine_exposes_async_engine_instance():
     db_engine = DatabaseEngine(database_url="sqlite+aiosqlite:///:memory:")
+
+    assert isinstance(db_engine.engine, AsyncEngine)
+
+
+def test_database_engine_uses_echo_true():
+    db_engine = DatabaseEngine(database_url="sqlite+aiosqlite:///:memory:")
+
+    assert db_engine.engine.echo is True
+
+
+def test_database_engine_sessionmaker_uses_async_session_class():
+    db_engine = DatabaseEngine(database_url="sqlite+aiosqlite:///:memory:")
+
+    async def run_test():
+        session = db_engine.async_session()
+        assert isinstance(session, AsyncSession)
+        await session.close()
+
+    asyncio.run(run_test())
+
+
+def test_database_engine_sessionmaker_disables_expire_on_commit():
+    db_engine = DatabaseEngine(database_url="sqlite+aiosqlite:///:memory:")
+
+    assert db_engine.async_session.kw["expire_on_commit"] is False
+
+
+def test_database_engine_get_session_yields_new_session_each_time():
+    db_engine = DatabaseEngine(database_url="sqlite+aiosqlite:///:memory:")
+
+    async def run_test():
+        generator_one = db_engine.get_session()
+        session_one = await generator_one.__anext__()
+
+        generator_two = db_engine.get_session()
+        session_two = await generator_two.__anext__()
+
+        assert session_one is not session_two
+
+        await generator_one.aclose()
+        await generator_two.aclose()
+
+    asyncio.run(run_test())
+
+
+def test_database_engine_get_session_can_be_consumed_with_async_for():
+    db_engine = DatabaseEngine(database_url="sqlite+aiosqlite:///:memory:")
+
+    async def run_test():
+        captured_session = None
+        async for session in db_engine.get_session():
+            captured_session = session
+            break
+
+        assert isinstance(captured_session, AsyncSession)
+
+    asyncio.run(run_test())
+
+
+def test_database_engine_init_db_creates_tables(tmp_path):
+    db_engine = DatabaseEngine(database_url=_sqlite_file_url(tmp_path))
 
     async def run_test():
         await db_engine.init_db()
@@ -35,3 +107,194 @@ def test_database_engine_init_db_creates_tables():
         assert "contributions" in table_names
 
     asyncio.run(run_test())
+
+
+def test_database_engine_init_db_creates_user_table(tmp_path):
+    db_engine = DatabaseEngine(database_url=_sqlite_file_url(tmp_path))
+
+    async def run_test():
+        await db_engine.init_db()
+        async with db_engine.engine.begin() as conn:
+            result = await conn.execute(
+                text("SELECT name FROM sqlite_master WHERE type='table' AND name='user'")
+            )
+            assert result.first() is not None
+
+    asyncio.run(run_test())
+
+
+def test_database_engine_init_db_creates_projects_table(tmp_path):
+    db_engine = DatabaseEngine(database_url=_sqlite_file_url(tmp_path))
+
+    async def run_test():
+        await db_engine.init_db()
+        async with db_engine.engine.begin() as conn:
+            result = await conn.execute(
+                text("SELECT name FROM sqlite_master WHERE type='table' AND name='projects'")
+            )
+            assert result.first() is not None
+
+    asyncio.run(run_test())
+
+
+def test_database_engine_init_db_creates_contributions_table(tmp_path):
+    db_engine = DatabaseEngine(database_url=_sqlite_file_url(tmp_path))
+
+    async def run_test():
+        await db_engine.init_db()
+        async with db_engine.engine.begin() as conn:
+            result = await conn.execute(
+                text("SELECT name FROM sqlite_master WHERE type='table' AND name='contributions'")
+            )
+            assert result.first() is not None
+
+    asyncio.run(run_test())
+
+
+def test_database_engine_init_db_is_idempotent(tmp_path):
+    db_engine = DatabaseEngine(database_url=_sqlite_file_url(tmp_path))
+
+    async def run_test():
+        await db_engine.init_db()
+        await db_engine.init_db()
+
+        async with db_engine.engine.begin() as conn:
+            result = await conn.execute(
+                text("SELECT name FROM sqlite_master WHERE type='table'")
+            )
+            table_names = {row[0] for row in result}
+
+        assert {"user", "projects", "contributions"}.issubset(table_names)
+
+    asyncio.run(run_test())
+
+
+def test_database_engine_init_db_allows_user_insert(tmp_path):
+    db_engine = DatabaseEngine(database_url=_sqlite_file_url(tmp_path))
+
+    async def run_test():
+        await db_engine.init_db()
+        async with db_engine.engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO user (id, username, email, password) "
+                    "VALUES (1, 'alice', 'alice@example.com', 'secret')"
+                )
+            )
+            result = await conn.execute(text("SELECT COUNT(*) FROM user"))
+            assert result.scalar_one() == 1
+
+    asyncio.run(run_test())
+
+
+def test_database_engine_init_db_allows_project_insert(tmp_path):
+    db_engine = DatabaseEngine(database_url=_sqlite_file_url(tmp_path))
+
+    async def run_test():
+        await db_engine.init_db()
+        async with db_engine.engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO projects (id, title, repository_url, help_wanted) "
+                    "VALUES (1, 'oss', 'https://github.com/example/oss', 1)"
+                )
+            )
+            result = await conn.execute(text("SELECT COUNT(*) FROM projects"))
+            assert result.scalar_one() == 1
+
+    asyncio.run(run_test())
+
+
+def test_database_engine_contributions_table_has_fk_user_column(tmp_path):
+    db_engine = DatabaseEngine(database_url=_sqlite_file_url(tmp_path))
+
+    async def run_test():
+        await db_engine.init_db()
+        async with db_engine.engine.begin() as conn:
+            result = await conn.execute(text("PRAGMA table_info('contributions')"))
+            columns = {row[1] for row in result}
+
+        assert "fk_user_id" in columns
+
+    asyncio.run(run_test())
+
+
+def test_database_engine_contributions_table_has_fk_project_column(tmp_path):
+    db_engine = DatabaseEngine(database_url=_sqlite_file_url(tmp_path))
+
+    async def run_test():
+        await db_engine.init_db()
+        async with db_engine.engine.begin() as conn:
+            result = await conn.execute(text("PRAGMA table_info('contributions')"))
+            columns = {row[1] for row in result}
+
+        assert "fk_project_id" in columns
+
+    asyncio.run(run_test())
+
+
+def test_database_engine_projects_table_help_wanted_is_not_nullable(tmp_path):
+    db_engine = DatabaseEngine(database_url=_sqlite_file_url(tmp_path))
+
+    async def run_test():
+        await db_engine.init_db()
+        async with db_engine.engine.begin() as conn:
+            result = await conn.execute(text("PRAGMA table_info('projects')"))
+            rows = list(result)
+
+        help_wanted_row = next(row for row in rows if row[1] == "help_wanted")
+        assert help_wanted_row[3] == 1
+
+    asyncio.run(run_test())
+
+
+def test_database_engine_user_table_has_unique_email_index(tmp_path):
+    db_engine = DatabaseEngine(database_url=_sqlite_file_url(tmp_path))
+
+    async def run_test():
+        await db_engine.init_db()
+        async with db_engine.engine.begin() as conn:
+            index_list = await conn.execute(text("PRAGMA index_list('user')"))
+            unique_indexes = [row for row in index_list if row[2] == 1]
+
+        assert len(unique_indexes) >= 1
+
+    asyncio.run(run_test())
+
+
+def test_database_engine_connection_can_execute_select_one():
+    db_engine = DatabaseEngine(database_url="sqlite+aiosqlite:///:memory:")
+
+    async def run_test():
+        async with db_engine.engine.connect() as conn:
+            result = await conn.execute(text("SELECT 1"))
+            assert result.scalar_one() == 1
+
+    asyncio.run(run_test())
+
+
+def test_database_engine_session_can_execute_select_one():
+    db_engine = DatabaseEngine(database_url="sqlite+aiosqlite:///:memory:")
+
+    async def run_test():
+        generator = db_engine.get_session()
+        session = await generator.__anext__()
+        result = await session.execute(text("SELECT 1"))
+
+        assert result.scalar_one() == 1
+
+        await generator.aclose()
+
+    asyncio.run(run_test())
+
+
+def test_database_engine_uses_sqlite_dialect_name_for_sqlite_url():
+    db_engine = DatabaseEngine(database_url="sqlite+aiosqlite:///:memory:")
+
+    assert db_engine.engine.dialect.name == "sqlite"
+
+
+def test_database_engine_uses_async_engine_driver_for_sqlite_url():
+    db_engine = DatabaseEngine(database_url="sqlite+aiosqlite:///:memory:")
+
+    assert db_engine.engine.driver == "aiosqlite"

--- a/backend/tests/test_project_sql_repository.py
+++ b/backend/tests/test_project_sql_repository.py
@@ -301,6 +301,9 @@ def test_list_default_pagination():
     asyncio.run(run())
 
     session.execute.assert_called_once()
+    statement = session.execute.call_args[0][0]
+    assert statement._offset_clause.value == 0
+    assert statement._limit_clause.value == 100
 
 
 def test_list_with_skip():
@@ -317,6 +320,9 @@ def test_list_with_skip():
     asyncio.run(run())
 
     session.execute.assert_called_once()
+    statement = session.execute.call_args[0][0]
+    assert statement._offset_clause.value == 10
+    assert statement._limit_clause.value == 100
 
 
 def test_list_with_limit():
@@ -333,6 +339,32 @@ def test_list_with_limit():
     asyncio.run(run())
 
     session.execute.assert_called_once()
+    statement = session.execute.call_args[0][0]
+    assert statement._offset_clause.value == 0
+    assert statement._limit_clause.value == 5
+
+
+def test_list_with_skip_and_limit_returns_paginated_result():
+    """Test that list returns only the paginated rows provided by the query result."""
+    session = make_session()
+    repo = make_repository(session)
+    mock_rows = [
+        ProjectModel(id=2, title="Project 2", repository_url="https://github.com/test/p2", created_at=DT, updated_at=DT),
+        ProjectModel(id=3, title="Project 3", repository_url="https://github.com/test/p3", created_at=DT, updated_at=DT),
+    ]
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = mock_rows
+    session.execute.return_value = mock_result
+
+    async def run():
+        return await repo.list(skip=1, limit=2)
+
+    projects = asyncio.run(run())
+
+    assert [project.id for project in projects] == [2, 3]
+    statement = session.execute.call_args[0][0]
+    assert statement._offset_clause.value == 1
+    assert statement._limit_clause.value == 2
 
 
 def test_list_returns_project_schemas():
@@ -503,6 +535,9 @@ def test_list_help_wanted_with_skip():
     asyncio.run(run())
 
     session.execute.assert_called_once()
+    statement = session.execute.call_args[0][0]
+    assert statement._offset_clause.value == 3
+    assert statement._limit_clause.value == 100
 
 
 def test_list_help_wanted_with_limit():
@@ -517,6 +552,34 @@ def test_list_help_wanted_with_limit():
         await repo.list_help_wanted(limit=5)
 
     asyncio.run(run())
+
+    session.execute.assert_called_once()
+    statement = session.execute.call_args[0][0]
+    assert statement._offset_clause.value == 0
+    assert statement._limit_clause.value == 5
+
+
+def test_list_help_wanted_with_skip_and_limit_returns_paginated_result():
+    """Test that list_help_wanted returns only the paginated help-wanted rows."""
+    session = make_session()
+    repo = make_repository(session)
+    mock_rows = [
+        ProjectModel(id=3, title="Help 3", repository_url="https://github.com/test/h3", help_wanted=True, created_at=DT, updated_at=DT),
+        ProjectModel(id=4, title="Help 4", repository_url="https://github.com/test/h4", help_wanted=True, created_at=DT, updated_at=DT),
+    ]
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = mock_rows
+    session.execute.return_value = mock_result
+
+    async def run():
+        return await repo.list_help_wanted(skip=2, limit=2)
+
+    projects = asyncio.run(run())
+
+    assert [project.id for project in projects] == [3, 4]
+    statement = session.execute.call_args[0][0]
+    assert statement._offset_clause.value == 2
+    assert statement._limit_clause.value == 2
 
     session.execute.assert_called_once()
 

--- a/backend/tests/test_project_sql_repository.py
+++ b/backend/tests/test_project_sql_repository.py
@@ -3,9 +3,20 @@ import asyncio
 from datetime import datetime
 import pytest
 from unittest.mock import AsyncMock, MagicMock, call
+from sqlalchemy.dialects import sqlite as _sqlite_dialect
 from app.projects.sql_repository import SqlRepository
 from app.projects.schemas import ProjectCreate
 from app.db.models import Project as ProjectModel
+
+
+def _compiled_sql(statement) -> str:
+    """Compile a SQLAlchemy statement to SQL text with literal bound values."""
+    return str(
+        statement.compile(
+            dialect=_sqlite_dialect.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
 
 
 DT = datetime(2026, 1, 1, 0, 0, 0)
@@ -302,8 +313,9 @@ def test_list_default_pagination():
 
     session.execute.assert_called_once()
     statement = session.execute.call_args[0][0]
-    assert statement._offset_clause.value == 0
-    assert statement._limit_clause.value == 100
+    sql = _compiled_sql(statement)
+    assert "LIMIT 100" in sql
+    assert "OFFSET 0" in sql
 
 
 def test_list_with_skip():
@@ -321,8 +333,9 @@ def test_list_with_skip():
 
     session.execute.assert_called_once()
     statement = session.execute.call_args[0][0]
-    assert statement._offset_clause.value == 10
-    assert statement._limit_clause.value == 100
+    sql = _compiled_sql(statement)
+    assert "LIMIT 100" in sql
+    assert "OFFSET 10" in sql
 
 
 def test_list_with_limit():
@@ -340,8 +353,9 @@ def test_list_with_limit():
 
     session.execute.assert_called_once()
     statement = session.execute.call_args[0][0]
-    assert statement._offset_clause.value == 0
-    assert statement._limit_clause.value == 5
+    sql = _compiled_sql(statement)
+    assert "LIMIT 5" in sql
+    assert "OFFSET 0" in sql
 
 
 def test_list_with_skip_and_limit_returns_paginated_result():
@@ -363,8 +377,9 @@ def test_list_with_skip_and_limit_returns_paginated_result():
 
     assert [project.id for project in projects] == [2, 3]
     statement = session.execute.call_args[0][0]
-    assert statement._offset_clause.value == 1
-    assert statement._limit_clause.value == 2
+    sql = _compiled_sql(statement)
+    assert "LIMIT 2" in sql
+    assert "OFFSET 1" in sql
 
 
 def test_list_returns_project_schemas():
@@ -536,8 +551,9 @@ def test_list_help_wanted_with_skip():
 
     session.execute.assert_called_once()
     statement = session.execute.call_args[0][0]
-    assert statement._offset_clause.value == 3
-    assert statement._limit_clause.value == 100
+    sql = _compiled_sql(statement)
+    assert "LIMIT 100" in sql
+    assert "OFFSET 3" in sql
 
 
 def test_list_help_wanted_with_limit():
@@ -555,8 +571,9 @@ def test_list_help_wanted_with_limit():
 
     session.execute.assert_called_once()
     statement = session.execute.call_args[0][0]
-    assert statement._offset_clause.value == 0
-    assert statement._limit_clause.value == 5
+    sql = _compiled_sql(statement)
+    assert "LIMIT 5" in sql
+    assert "OFFSET 0" in sql
 
 
 def test_list_help_wanted_with_skip_and_limit_returns_paginated_result():
@@ -578,8 +595,9 @@ def test_list_help_wanted_with_skip_and_limit_returns_paginated_result():
 
     assert [project.id for project in projects] == [3, 4]
     statement = session.execute.call_args[0][0]
-    assert statement._offset_clause.value == 2
-    assert statement._limit_clause.value == 2
+    sql = _compiled_sql(statement)
+    assert "LIMIT 2" in sql
+    assert "OFFSET 2" in sql
 
     session.execute.assert_called_once()
 

--- a/backend/tests/test_project_sql_service.py
+++ b/backend/tests/test_project_sql_service.py
@@ -146,6 +146,89 @@ def test_create_error_message_contains_repository_url():
     asyncio.run(run())
 
 
+def test_create_calls_lookup_before_create():
+    """create should check URL uniqueness before attempting repository.create."""
+    repository = make_repository()
+    service = make_service(repository)
+    payload = ProjectCreate(
+        title="Ordered Project",
+        repository_url="https://github.com/test/ordered",
+        help_wanted=False,
+    )
+    repository.get_by_repository_url.return_value = None
+    repository.create.return_value = make_project(repository_url=str(payload.repository_url))
+
+    async def run():
+        await service.create(payload)
+
+    asyncio.run(run())
+
+    call_names = [call[0] for call in repository.mock_calls]
+    assert "get_by_repository_url" in call_names
+    assert "create" in call_names
+    assert call_names.index("get_by_repository_url") < call_names.index("create")
+
+
+def test_create_propagates_lookup_exception():
+    """create should bubble up repository errors during duplicate URL lookup."""
+    repository = make_repository()
+    service = make_service(repository)
+    payload = ProjectCreate(
+        title="Lookup Failure",
+        repository_url="https://github.com/test/lookup-failure",
+        help_wanted=False,
+    )
+    repository.get_by_repository_url.side_effect = RuntimeError("lookup failed")
+
+    async def run():
+        with pytest.raises(RuntimeError, match="lookup failed"):
+            await service.create(payload)
+
+    asyncio.run(run())
+
+    repository.create.assert_not_called()
+
+
+def test_create_propagates_create_exception():
+    """create should bubble up repository errors raised while persisting the project."""
+    repository = make_repository()
+    service = make_service(repository)
+    payload = ProjectCreate(
+        title="Persist Failure",
+        repository_url="https://github.com/test/persist-failure",
+        help_wanted=False,
+    )
+    repository.get_by_repository_url.return_value = None
+    repository.create.side_effect = RuntimeError("create failed")
+
+    async def run():
+        with pytest.raises(RuntimeError, match="create failed"):
+            await service.create(payload)
+
+    asyncio.run(run())
+
+
+def test_create_passes_same_payload_instance_to_repository():
+    """create should pass through the same ProjectCreate instance received by the service."""
+    repository = make_repository()
+    service = make_service(repository)
+    payload = ProjectCreate(
+        title="Identity Project",
+        repository_url="https://github.com/test/identity",
+        help_wanted=False,
+    )
+    repository.get_by_repository_url.return_value = None
+    repository.create.return_value = make_project(repository_url=str(payload.repository_url))
+
+    async def run():
+        await service.create(payload)
+
+    asyncio.run(run())
+
+    forwarded_payload = repository.create.call_args[0][0]
+    assert forwarded_payload is payload
+
+
 # ---------------------------------------------------------------------------
 # list
 # ---------------------------------------------------------------------------
@@ -181,6 +264,61 @@ def test_list_forwards_custom_pagination():
     asyncio.run(run())
 
     repository.list.assert_called_once_with(skip=10, limit=25)
+
+
+@pytest.mark.parametrize(
+    "skip,limit",
+    [
+        (0, 100),
+        (0, 1),
+        (3, 5),
+        (10, 0),
+    ],
+)
+def test_list_forwards_pagination_matrix(skip, limit):
+    """list should forward different pagination combinations to repository.list."""
+    repository = make_repository()
+    service = make_service(repository)
+    repository.list.return_value = []
+
+    async def run():
+        await service.list(skip=skip, limit=limit)
+
+    asyncio.run(run())
+
+    repository.list.assert_called_once_with(skip=skip, limit=limit)
+
+
+def test_list_propagates_repository_exception():
+    """list should bubble up errors coming from repository.list."""
+    repository = make_repository()
+    service = make_service(repository)
+    repository.list.side_effect = RuntimeError("list failed")
+
+    async def run():
+        with pytest.raises(RuntimeError, match="list failed"):
+            await service.list()
+
+    asyncio.run(run())
+
+
+def test_list_returns_paginated_subset_from_repository():
+    """list should return the subset produced by the repository for the requested pagination."""
+    repository = make_repository()
+    service = make_service(repository)
+    paginated_projects = [
+        make_project(id=2, title="Project B"),
+        make_project(id=3, title="Project C", repository_url="https://github.com/test/c"),
+    ]
+    repository.list.return_value = paginated_projects
+
+    async def run():
+        result = await service.list(skip=1, limit=2)
+        assert [project.id for project in result] == [2, 3]
+
+    asyncio.run(run())
+
+    repository.list.assert_called_once_with(skip=1, limit=2)
 
 
 def test_list_returns_empty_list_when_no_projects():
@@ -246,6 +384,33 @@ def test_get_by_id_error_message_contains_project_id():
     asyncio.run(run())
 
 
+def test_get_by_id_returns_same_repository_instance():
+    """get_by_id should return the same schema object returned by repository.get_by_id."""
+    repository = make_repository()
+    service = make_service(repository)
+    project = make_project(id=51, title="Identity Return")
+    repository.get_by_id.return_value = project
+
+    async def run():
+        result = await service.get_by_id(51)
+        assert result is project
+
+    asyncio.run(run())
+
+
+def test_get_by_id_propagates_repository_exception():
+    """get_by_id should bubble up repository errors unrelated to not-found cases."""
+    repository = make_repository()
+    service = make_service(repository)
+    repository.get_by_id.side_effect = RuntimeError("db unavailable")
+
+    async def run():
+        with pytest.raises(RuntimeError, match="db unavailable"):
+            await service.get_by_id(7)
+
+    asyncio.run(run())
+
+
 # ---------------------------------------------------------------------------
 # list_help_wanted
 # ---------------------------------------------------------------------------
@@ -267,7 +432,7 @@ def test_list_help_wanted_returns_only_flagged_projects():
 
     asyncio.run(run())
 
-    repository.list_help_wanted.assert_called_once()
+    repository.list_help_wanted.assert_called_once_with(skip=0, limit=100)
 
 
 def test_list_help_wanted_returns_empty_list_when_no_flagged_projects():
@@ -282,4 +447,90 @@ def test_list_help_wanted_returns_empty_list_when_no_flagged_projects():
 
     asyncio.run(run())
 
-    repository.list_help_wanted.assert_called_once()
+    repository.list_help_wanted.assert_called_once_with(skip=0, limit=100)
+
+
+def test_list_help_wanted_forwards_custom_pagination():
+    """list_help_wanted should forward custom skip and limit to the repository."""
+    repository = make_repository()
+    service = make_service(repository)
+    repository.list_help_wanted.return_value = []
+
+    async def run():
+        await service.list_help_wanted(skip=4, limit=6)
+
+    asyncio.run(run())
+
+    repository.list_help_wanted.assert_called_once_with(skip=4, limit=6)
+
+
+@pytest.mark.parametrize(
+    "skip,limit",
+    [
+        (0, 100),
+        (0, 2),
+        (2, 3),
+        (6, 0),
+    ],
+)
+def test_list_help_wanted_forwards_pagination_matrix(skip, limit):
+    """list_help_wanted should forward different pagination combinations."""
+    repository = make_repository()
+    service = make_service(repository)
+    repository.list_help_wanted.return_value = []
+
+    async def run():
+        await service.list_help_wanted(skip=skip, limit=limit)
+
+    asyncio.run(run())
+
+    repository.list_help_wanted.assert_called_once_with(skip=skip, limit=limit)
+
+
+def test_list_help_wanted_propagates_repository_exception():
+    """list_help_wanted should bubble up repository.list_help_wanted failures."""
+    repository = make_repository()
+    service = make_service(repository)
+    repository.list_help_wanted.side_effect = RuntimeError("help_wanted failed")
+
+    async def run():
+        with pytest.raises(RuntimeError, match="help_wanted failed"):
+            await service.list_help_wanted()
+
+    asyncio.run(run())
+
+
+def test_list_help_wanted_preserves_repository_order():
+    """list_help_wanted should preserve project ordering from repository output."""
+    repository = make_repository()
+    service = make_service(repository)
+    repository.list_help_wanted.return_value = [
+        make_project(id=5, title="Open E", help_wanted=True),
+        make_project(id=2, title="Open B", repository_url="https://github.com/test/open-b", help_wanted=True),
+        make_project(id=9, title="Open I", repository_url="https://github.com/test/open-i", help_wanted=True),
+    ]
+
+    async def run():
+        result = await service.list_help_wanted()
+        assert [project.id for project in result] == [5, 2, 9]
+
+    asyncio.run(run())
+
+
+def test_list_help_wanted_returns_paginated_subset_from_repository():
+    """list_help_wanted should return the paginated subset produced by the repository."""
+    repository = make_repository()
+    service = make_service(repository)
+    paginated_help_wanted = [
+        make_project(id=2, title="Open B", help_wanted=True),
+        make_project(id=3, title="Open C", repository_url="https://github.com/test/open-c", help_wanted=True),
+    ]
+    repository.list_help_wanted.return_value = paginated_help_wanted
+
+    async def run():
+        result = await service.list_help_wanted(skip=1, limit=2)
+        assert [project.id for project in result] == [2, 3]
+
+    asyncio.run(run())
+
+    repository.list_help_wanted.assert_called_once_with(skip=1, limit=2)

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -46,8 +46,12 @@ def test_settings_is_immutable():
         config.POSTGRES_DB = "other"
 
 
-def test_settings_default_host_and_port_are_applied():
+def test_settings_default_host_and_port_are_applied(monkeypatch):
+    monkeypatch.delenv("POSTGRES_HOST", raising=False)
+    monkeypatch.delenv("POSTGRES_PORT", raising=False)
+
     config = PSQLSettings(
+        _env_file=None,
         POSTGRES_USER="user",
         POSTGRES_PASSWORD="pass",
         POSTGRES_DB="db",
@@ -57,8 +61,13 @@ def test_settings_default_host_and_port_are_applied():
     assert config.POSTGRES_PORT == 5432
 
 
-def test_settings_app_defaults_are_present():
+def test_settings_app_defaults_are_present(monkeypatch):
+    monkeypatch.delenv("APP_NAME", raising=False)
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+    monkeypatch.delenv("DEBUG", raising=False)
+
     config = PSQLSettings(
+        _env_file=None,
         POSTGRES_USER="user",
         POSTGRES_PASSWORD="pass",
         POSTGRES_DB="db",

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -1,7 +1,13 @@
 import pytest
 from pydantic import ValidationError
 
-from app.core.settings import DBSettings, PSQLSettings, get_psql_settings, settings
+from app.core.settings import (
+    DBSettings,
+    PSQLSettings,
+    _get_default_env_file,
+    get_psql_settings,
+    settings,
+)
 
 
 def test_settings_singleton_instance():
@@ -38,3 +44,287 @@ def test_settings_is_immutable():
 
     with pytest.raises(ValidationError):
         config.POSTGRES_DB = "other"
+
+
+def test_settings_default_host_and_port_are_applied():
+    config = PSQLSettings(
+        POSTGRES_USER="user",
+        POSTGRES_PASSWORD="pass",
+        POSTGRES_DB="db",
+    )
+
+    assert config.POSTGRES_HOST == "localhost"
+    assert config.POSTGRES_PORT == 5432
+
+
+def test_settings_app_defaults_are_present():
+    config = PSQLSettings(
+        POSTGRES_USER="user",
+        POSTGRES_PASSWORD="pass",
+        POSTGRES_DB="db",
+    )
+
+    assert config.APP_NAME == "OSSN Backend"
+    assert config.ENVIRONMENT == "development"
+    assert config.DEBUG is False
+
+
+def test_settings_jwt_defaults_are_present(monkeypatch):
+    monkeypatch.delenv("JWT_CURRENT_SECRET", raising=False)
+    monkeypatch.delenv("JWT_PREVIOUS_SECRETS", raising=False)
+    monkeypatch.delenv("JWT_ALGORITHM", raising=False)
+    monkeypatch.delenv("JWT_EXPIRATION_MINUTES", raising=False)
+
+    config = PSQLSettings(
+        _env_file=None,
+        POSTGRES_USER="user",
+        POSTGRES_PASSWORD="pass",
+        POSTGRES_DB="db",
+    )
+
+    assert config.JWT_CURRENT_SECRET == "changeme-replace-this-key-in-production-env"
+    assert config.JWT_PREVIOUS_SECRETS == ""
+    assert config.JWT_ALGORITHM == "HS256"
+    assert config.JWT_EXPIRATION_MINUTES == 30
+
+
+def test_settings_accepts_custom_jwt_values():
+    config = PSQLSettings(
+        POSTGRES_USER="user",
+        POSTGRES_PASSWORD="pass",
+        POSTGRES_DB="db",
+        JWT_CURRENT_SECRET="current-secret",
+        JWT_PREVIOUS_SECRETS="old1,old2",
+        JWT_ALGORITHM="HS512",
+        JWT_EXPIRATION_MINUTES=90,
+    )
+
+    assert config.JWT_CURRENT_SECRET == "current-secret"
+    assert config.JWT_PREVIOUS_SECRETS == "old1,old2"
+    assert config.JWT_ALGORITHM == "HS512"
+    assert config.JWT_EXPIRATION_MINUTES == 90
+
+
+def test_settings_ignores_unknown_fields():
+    config = PSQLSettings(
+        POSTGRES_USER="user",
+        POSTGRES_PASSWORD="pass",
+        POSTGRES_DB="db",
+        UNKNOWN_KEY="ignored",
+    )
+
+    assert not hasattr(config, "UNKNOWN_KEY")
+
+
+@pytest.mark.parametrize(
+    "host,port,expected",
+    [
+        ("localhost", 5432, "postgresql+asyncpg://user:pass@localhost:5432/db"),
+        ("db", 5433, "postgresql+asyncpg://user:pass@db:5433/db"),
+        ("127.0.0.1", 6543, "postgresql+asyncpg://user:pass@127.0.0.1:6543/db"),
+        ("postgres.internal", 9999, "postgresql+asyncpg://user:pass@postgres.internal:9999/db"),
+    ],
+)
+def test_db_url_varies_with_host_and_port(host, port, expected):
+    config = PSQLSettings(
+        POSTGRES_USER="user",
+        POSTGRES_PASSWORD="pass",
+        POSTGRES_DB="db",
+        POSTGRES_HOST=host,
+        POSTGRES_PORT=port,
+    )
+
+    assert config.db_url == expected
+
+
+@pytest.mark.parametrize("port", [1, 5432, 65535, "5434"])
+def test_settings_accepts_valid_postgres_port_values(port):
+    config = PSQLSettings(
+        POSTGRES_USER="user",
+        POSTGRES_PASSWORD="pass",
+        POSTGRES_DB="db",
+        POSTGRES_PORT=port,
+    )
+
+    assert isinstance(config.POSTGRES_PORT, int)
+
+
+@pytest.mark.parametrize("bad_port", ["not-an-int", "", None])
+def test_settings_rejects_invalid_postgres_port_values(bad_port):
+    with pytest.raises(ValidationError):
+        PSQLSettings(
+            POSTGRES_USER="user",
+            POSTGRES_PASSWORD="pass",
+            POSTGRES_DB="db",
+            POSTGRES_PORT=bad_port,
+        )
+
+
+@pytest.mark.parametrize("minutes", [1, 30, 120, "45"])
+def test_settings_accepts_valid_jwt_expiration_values(minutes):
+    config = PSQLSettings(
+        POSTGRES_USER="user",
+        POSTGRES_PASSWORD="pass",
+        POSTGRES_DB="db",
+        JWT_EXPIRATION_MINUTES=minutes,
+    )
+
+    assert isinstance(config.JWT_EXPIRATION_MINUTES, int)
+
+
+@pytest.mark.parametrize("bad_minutes", ["soon", "", None])
+def test_settings_rejects_invalid_jwt_expiration_values(bad_minutes):
+    with pytest.raises(ValidationError):
+        PSQLSettings(
+            POSTGRES_USER="user",
+            POSTGRES_PASSWORD="pass",
+            POSTGRES_DB="db",
+            JWT_EXPIRATION_MINUTES=bad_minutes,
+        )
+
+
+@pytest.mark.parametrize("algo", ["HS256", "HS384", "HS512"])
+def test_settings_accepts_jwt_algorithm_strings(algo):
+    config = PSQLSettings(
+        POSTGRES_USER="user",
+        POSTGRES_PASSWORD="pass",
+        POSTGRES_DB="db",
+        JWT_ALGORITHM=algo,
+    )
+
+    assert config.JWT_ALGORITHM == algo
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("POSTGRES_USER", None),
+        ("POSTGRES_PASSWORD", None),
+        ("POSTGRES_DB", None),
+    ],
+)
+def test_settings_requires_mandatory_postgres_fields(field, value):
+    kwargs = {
+        "POSTGRES_USER": "user",
+        "POSTGRES_PASSWORD": "pass",
+        "POSTGRES_DB": "db",
+    }
+    kwargs[field] = value
+
+    with pytest.raises(ValidationError):
+        PSQLSettings(**kwargs)
+
+
+def test_default_env_file_path_points_to_dotenv_name():
+    env_path = _get_default_env_file()
+
+    assert env_path.name == ".env"
+
+
+def test_get_psql_settings_returns_psql_settings_instance(monkeypatch):
+    get_psql_settings.cache_clear()
+    monkeypatch.setenv("POSTGRES_USER", "env_user")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "env_pass")
+    monkeypatch.setenv("POSTGRES_DB", "env_db")
+    monkeypatch.setenv("POSTGRES_HOST", "env_host")
+    monkeypatch.setenv("POSTGRES_PORT", "5544")
+
+    instance = get_psql_settings()
+
+    assert isinstance(instance, PSQLSettings)
+    get_psql_settings.cache_clear()
+
+
+def test_get_psql_settings_uses_environment_values(monkeypatch):
+    get_psql_settings.cache_clear()
+    monkeypatch.setenv("POSTGRES_USER", "env_user")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "env_pass")
+    monkeypatch.setenv("POSTGRES_DB", "env_db")
+    monkeypatch.setenv("POSTGRES_HOST", "env_host")
+    monkeypatch.setenv("POSTGRES_PORT", "7777")
+
+    instance = get_psql_settings()
+
+    assert instance.POSTGRES_USER == "env_user"
+    assert instance.POSTGRES_PASSWORD == "env_pass"
+    assert instance.POSTGRES_DB == "env_db"
+    assert instance.POSTGRES_HOST == "env_host"
+    assert instance.POSTGRES_PORT == 7777
+    get_psql_settings.cache_clear()
+
+
+def test_get_psql_settings_cache_does_not_refresh_without_cache_clear(monkeypatch):
+    get_psql_settings.cache_clear()
+    monkeypatch.setenv("POSTGRES_USER", "first_user")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "first_pass")
+    monkeypatch.setenv("POSTGRES_DB", "first_db")
+    first = get_psql_settings()
+
+    monkeypatch.setenv("POSTGRES_USER", "second_user")
+    second = get_psql_settings()
+
+    assert first is second
+    assert second.POSTGRES_USER == "first_user"
+    get_psql_settings.cache_clear()
+
+
+def test_get_psql_settings_cache_refreshes_after_cache_clear(monkeypatch):
+    get_psql_settings.cache_clear()
+    monkeypatch.setenv("POSTGRES_USER", "first_user")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "first_pass")
+    monkeypatch.setenv("POSTGRES_DB", "first_db")
+    first = get_psql_settings()
+
+    get_psql_settings.cache_clear()
+    monkeypatch.setenv("POSTGRES_USER", "second_user")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "second_pass")
+    monkeypatch.setenv("POSTGRES_DB", "second_db")
+    second = get_psql_settings()
+
+    assert first is not second
+    assert second.POSTGRES_USER == "second_user"
+    get_psql_settings.cache_clear()
+
+
+def test_db_url_contains_database_name_component():
+    config = PSQLSettings(
+        POSTGRES_USER="user",
+        POSTGRES_PASSWORD="pass",
+        POSTGRES_DB="my_database",
+    )
+
+    assert config.db_url.endswith("/my_database")
+
+
+def test_db_url_includes_credentials_and_host_information():
+    config = PSQLSettings(
+        POSTGRES_USER="alice",
+        POSTGRES_PASSWORD="secret",
+        POSTGRES_DB="work",
+        POSTGRES_HOST="postgres",
+        POSTGRES_PORT=5435,
+    )
+
+    assert "alice:secret@postgres:5435" in config.db_url
+
+
+def test_settings_supports_empty_previous_jwt_secrets():
+    config = PSQLSettings(
+        POSTGRES_USER="user",
+        POSTGRES_PASSWORD="pass",
+        POSTGRES_DB="db",
+        JWT_PREVIOUS_SECRETS="",
+    )
+
+    assert config.JWT_PREVIOUS_SECRETS == ""
+
+
+def test_settings_supports_non_empty_previous_jwt_secrets():
+    config = PSQLSettings(
+        POSTGRES_USER="user",
+        POSTGRES_PASSWORD="pass",
+        POSTGRES_DB="db",
+        JWT_PREVIOUS_SECRETS="k1,k2,k3",
+    )
+
+    assert config.JWT_PREVIOUS_SECRETS == "k1,k2,k3"


### PR DESCRIPTION
## Summary

This PR implements and hardens project retrieval flows for the Projects API, including:
- list all projects
- list help-wanted projects
- get project by id

It also expands and stabilizes test coverage significantly across API, service, repository, settings, DB models, and DB session layers.

## What Was Implemented

### Projects API
- Implemented `GET /projects/` using service delegation (`list`) with pagination (`skip`, `limit`).
- Implemented `GET /projects/help-wanted` using service delegation (`list_help_wanted`) with pagination.
- Implemented `GET /projects/{project_id}` using service delegation (`get_by_id`) with 404 mapping when project is not found.
- Added/updated endpoint docstrings for clarity and behavior expectations.

### Service and Repository Layer
- Implemented/updated `list_help_wanted` behavior in SQL service.
- Aligned `list_help_wanted` signatures and pagination behavior across service/repository contracts and implementations.
- Improved docstrings in service/repository for maintainability and clearer interface semantics.

## Test Coverage Improvements

### API tests
- Added coverage for:
  - successful listing and retrieval
  - pagination forwarding and paginated subset behavior
  - delegation assertions
  - `404` mapping for not-found project id
  - unexpected error propagation (`500` behavior)

### SQL service tests
- Expanded coverage for:
  - create flow ordering and duplicate URL conflict behavior
  - passthrough and pagination for list/list_help_wanted
  - exception propagation
  - object/result consistency checks

### SQL repository tests
- Added assertions validating query pagination behavior (offset/limit).
- Added list/list_help_wanted paginated subset scenarios.

### Settings tests
- Expanded from minimal checks to robust validation:
  - defaults
  - parsing/coercion
  - environment loading behavior
  - cache behavior (`get_psql_settings`)
  - deterministic JWT default checks

### DB model tests
- Expanded coverage for:
  - metadata/table registration
  - constraints and nullability
  - FK targets and cascade behavior
  - relationship wiring
  - defaults/onupdate behavior

### DB session tests
- Expanded coverage for:
  - engine/sessionmaker configuration
  - session generator behavior
  - schema initialization/idempotency
  - SQLite schema inspection and execution checks

## Stability / Validation

- Targeted module test runs were executed during implementation.
- Full backend test suite passes after all changes:

`575 passed`

## Why This PR

This PR completes the project retrieval API behavior end-to-end while improving confidence and maintainability through broad, meaningful automated test coverage.