### PR TITLE
feat(auth) : wire backend auth bootstrap and local DB setup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,13 @@
 
 from fastapi import FastAPI
 
+from app.auth.api import router as auth_router
+from app.contributions.api import router as contributions_router
+from app.projects.api import router as projects_router
+
+
 app = FastAPI()
+
+app.include_router(auth_router)
+app.include_router(projects_router)
+app.include_router(contributions_router)

--- a/db.sql
+++ b/db.sql
@@ -50,6 +50,19 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER updated_user_modtime BEFORE UPDATE ON "user" FOR EACH ROW EXECUTE update_updated_at_column();
-CREATE TRIGGER updated_projects_modtime BEFORE UPDATE ON "projects" FOR EACH ROW EXECUTE update_updated_at_column();
-CREATE TRIGGER updated_contributions_modtime BEFORE UPDATE ON "contributions" FOR EACH ROW EXECUTE update_updated_at_column();
+CREATE TRIGGER updated_user_modtime BEFORE UPDATE ON "user" FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER updated_projects_modtime BEFORE UPDATE ON "projects" FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER updated_contributions_modtime BEFORE UPDATE ON "contributions" FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Seed a local user for development login.
+INSERT INTO "user" (username, email, password)
+VALUES (
+    'root',
+    'user@email.com',
+    'pbkdf2_sha256$390000$00112233445566778899aabbccddeeff$9ba32628e6be908d57cd30f1359b68ab0a9891f72a49afcd40645101b208a951'
+)
+ON CONFLICT (email) DO UPDATE
+SET
+    username = EXCLUDED.username,
+    password = EXCLUDED.password,
+    updated_at = CURRENT_TIMESTAMP;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       # This line handles the automatic initialization
       - ./db.sql:/docker-entrypoint-initdb.d/db.sql:ro
     ports:
-      - 5432:5432
+      - 5433:5432
 
 volumes:
   pgdata:


### PR DESCRIPTION
# Fix the backend and the docker-compose database

closed #82 

- register the auth, projects, and contributions routers in the FastAPI app entrypoint.
- fix PostgreSQL trigger declarations to use EXECUTE FUNCTION in db.sql.
- seed a local development user for authentication testing during DB initialization.
- expose the database container on host port 5433 to avoid local conflicts on 5432.