### PR TITLE
feat(backend) : add a /api prefix to each endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,5 @@
 
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 
 from app.auth.api import router as auth_router
 from app.contributions.api import router as contributions_router
@@ -8,6 +8,9 @@ from app.projects.api import router as projects_router
 
 app = FastAPI()
 
-app.include_router(auth_router)
-app.include_router(projects_router)
-app.include_router(contributions_router)
+api_router = APIRouter(prefix="/api")
+api_router.include_router(auth_router)
+api_router.include_router(projects_router)
+api_router.include_router(contributions_router)
+
+app.include_router(api_router)


### PR DESCRIPTION
close #80 

* Wrap feature routers in a parent FastAPI router with the /api prefix.
* Keep package-level route prefixes unchanged, such as /auth and /projects.
* Centralize API path versioning/prefixing in one place instead of repeating it across modules.
* Make endpoint URLs consistent without modifying each router definition individually.